### PR TITLE
Bug 652221: parts 5 through 11; starting to add meat. v1

### DIFF
--- a/services/sync/modules/engines.js
+++ b/services/sync/modules/engines.js
@@ -54,6 +54,7 @@ Cu.import("resource://services-sync/identity.js");
 Cu.import("resource://services-sync/log4moz.js");
 Cu.import("resource://services-sync/resource.js");
 Cu.import("resource://services-sync/util.js");
+Cu.import("resource://services-sync/async.js");
 
 Cu.import("resource://services-sync/main.js");    // So we can get to Service for callbacks.
 
@@ -1087,20 +1088,40 @@ SyncEngine.prototype = {
     return canDecrypt;
   },
 
+  _resetClientCb: function _resetClientCb(callback) {
+    try {
+      this.resetLastSync();
+      this.previousFailed = [];
+      this.toFetch = [];
+      callback();
+    } catch (ex) {
+      callback(ex);
+    }
+  },
+
+  wipeServerCb: function wipeServerCb(callback) {
+    let self = this;
+    let cb = function(err) {
+      if (!err)
+        self._resetClientCb(callback);
+      else
+        callback(err);
+    };
+    new AsyncResource(this.engineURL).delete(cb);
+  },
+
   _resetClient: function SyncEngine__resetClient() {
-    this.resetLastSync();
-    this.previousFailed = [];
-    this.toFetch = [];
+    Async.callSpinningly(this, this._resetClientCb);
   },
 
   wipeServer: function wipeServer() {
-    new Resource(this.engineURL).delete();
-    this._resetClient();
+    return Async.callSpinningly(this, this.wipeServerCb);
   },
 
-  removeClientData: function removeClientData() {
+  removeClientData: function removeClientData(callback) {
     // Implement this method in engines that store client specific data
     // on the server.
+    callback();
   },
 
   /*

--- a/services/sync/modules/engines.js
+++ b/services/sync/modules/engines.js
@@ -556,14 +556,23 @@ SyncEngine.prototype = {
   },
 
   // Any setup that needs to happen at the beginning of each sync.
-  _syncStartup: function SyncEngine__syncStartup() {
+  _syncStartupCb: function _syncStartupCb(callback) {
+    try {
+      this._syncStartupUnsafe(callback);
+    } catch (ex) {
+      callback(ex);
+    }
+  },
 
+  // This is wrapped in a try block by _syncStartupCb.
+  _syncStartupUnsafe: function _syncStartupUnsafe(callback) {
     // Determine if we need to wipe on outdated versions
     let metaGlobal = Records.get(this.metaURL);
     let engines = metaGlobal.payload.engines || {};
     let engineData = engines[this.name] || {};
 
     let needsWipe = false;
+    let bouncer = function(f) f();
 
     // Assume missing versions are 0 and wipe the server
     if ((engineData.version || 0) < this.version) {
@@ -592,43 +601,50 @@ SyncEngine.prototype = {
     else if (engineData.syncID != this.syncID) {
       this._log.debug("Engine syncIDs: " + [engineData.syncID, this.syncID]);
       this.syncID = engineData.syncID;
-      this._resetClient();
-    };
-
-    // Delete any existing data and reupload on bad version or missing meta.
-    // No crypto component here...? We could regenerate per-collection keys...
-    if (needsWipe) {
-      this.wipeServer(true);
+      bouncer = this._resetClientCb;
     }
 
-    // Save objects that need to be uploaded in this._modified. We also save
-    // the timestamp of this fetch in this.lastSyncLocal. As we successfully
-    // upload objects we remove them from this._modified. If an error occurs
-    // or any objects fail to upload, they will remain in this._modified. At
-    // the end of a sync, or after an error, we add all objects remaining in
-    // this._modified to the tracker.
-    this.lastSyncLocal = Date.now();
-    if (this.lastSync) {
-      this._modified = this.getChangedIDs();
-    } else {
-      // Mark all items to be uploaded, but treat them as changed from long ago
-      this._log.debug("First sync, uploading all items");
-      this._modified = {};
-      for (let id in this._store.getAllIDs())
-        this._modified[id] = 0;
-    }
-    // Clear the tracker now. If the sync fails we'll add the ones we failed
-    // to upload back.
-    this._tracker.clearChangedIDs();
- 
-    // Array of just the IDs from this._modified. This is what we iterate over
-    // so we can modify this._modified during the iteration.
-    this._modifiedIDs = [id for (id in this._modified)];
-    this._log.info(this._modifiedIDs.length +
-                   " outgoing items pre-reconciliation");
+    bouncer.call(this, function (error) {
+      if (error) {
+        throw error;         // Will get caught by our wrapper.
+      }
 
-    // Keep track of what to delete at the end of sync
-    this._delete = {};
+      // Delete any existing data and reupload on bad version or missing meta.
+      // No crypto component here...? We could regenerate per-collection keys...
+      if (needsWipe) {
+        this.wipeServer(true);
+      }
+
+      // Save objects that need to be uploaded in this._modified. We also save
+      // the timestamp of this fetch in this.lastSyncLocal. As we successfully
+      // upload objects we remove them from this._modified. If an error occurs
+      // or any objects fail to upload, they will remain in this._modified. At
+      // the end of a sync, or after an error, we add all objects remaining in
+      // this._modified to the tracker.
+      this.lastSyncLocal = Date.now();
+      if (this.lastSync) {
+        this._modified = this.getChangedIDs();
+      } else {
+        // Mark all items to be uploaded, but treat them as changed from long ago
+        this._log.debug("First sync, uploading all items");
+        this._modified = {};
+        for (let id in this._store.getAllIDs())
+          this._modified[id] = 0;
+      }
+      // Clear the tracker now. If the sync fails we'll add the ones we failed
+      // to upload back.
+      this._tracker.clearChangedIDs();
+
+      // Array of just the IDs from this._modified. This is what we iterate over
+      // so we can modify this._modified during the iteration.
+      this._modifiedIDs = [id for (id in this._modified)];
+      this._log.info(this._modifiedIDs.length +
+                     " outgoing items pre-reconciliation");
+
+      // Keep track of what to delete at the end of sync
+      this._delete = {};
+      callback();
+    }.bind(this));
   },
 
   // Process incoming records
@@ -1051,12 +1067,16 @@ SyncEngine.prototype = {
 
   _sync: function SyncEngine__sync() {
     try {
-      this._syncStartup();
-      Observers.notify("weave:engine:sync:status", "process-incoming");
-      this._processIncoming();
-      Observers.notify("weave:engine:sync:status", "upload-outgoing");
-      this._uploadOutgoing();
-      this._syncFinish();
+      this._syncStartupCb(function (err) {
+        if (err) {
+          throw err;
+        }
+        Observers.notify("weave:engine:sync:status", "process-incoming");
+        this._processIncoming();
+        Observers.notify("weave:engine:sync:status", "upload-outgoing");
+        this._uploadOutgoing();
+        this._syncFinish();
+      }.bind(this));
     } finally {
       this._syncCleanup();
     }
@@ -1100,13 +1120,12 @@ SyncEngine.prototype = {
   },
 
   wipeServerCb: function wipeServerCb(callback) {
-    let self = this;
     let cb = function(err) {
       if (!err)
-        self._resetClientCb(callback);
+        this._resetClientCb(callback);
       else
         callback(err);
-    };
+    }.bind(this);
     new AsyncResource(this.engineURL).delete(cb);
   },
 

--- a/services/sync/modules/engines.js
+++ b/services/sync/modules/engines.js
@@ -305,7 +305,7 @@ EngineManagerSvc.prototype = {
   getEnabled: function EngMgr_getEnabled() {
     return this.getAll().filter(function(engine) engine.enabled);
   },
-  
+
   /**
    * Register an Engine to the service. Alternatively, give an array of engine
    * objects to register.
@@ -392,7 +392,7 @@ Engine.prototype = {
   },
 
   /**
-   * Get rid of any local meta-data
+   * Get rid of any local metadata.
    */
   resetClient: function Engine_resetClient() {
     if (!this._resetClient)
@@ -433,16 +433,16 @@ SyncEngine.prototype = {
   __proto__: Engine.prototype,
   _recordObj: CryptoWrapper,
   version: 1,
-  
+
   // How many records to pull in a single sync. This is primarily to avoid very
   // long first syncs against profiles with many history records.
   downloadLimit: null,
-  
+
   // How many records to pull at one time when specifying IDs. This is to avoid
   // URI length limitations.
   guidFetchBatchSize: DEFAULT_GUID_FETCH_BATCH_SIZE,
   mobileGUIDFetchBatchSize: DEFAULT_MOBILE_GUID_FETCH_BATCH_SIZE,
-  
+
   // How many records to process in a single batch.
   applyIncomingBatchSize: DEFAULT_STORE_BATCH_SIZE,
 
@@ -691,7 +691,7 @@ SyncEngine.prototype = {
 
       // Track the collection for the WBO.
       item.collection = self.name;
-      
+
       // Remember which records were processed
       handled.push(item.id);
 
@@ -711,7 +711,7 @@ SyncEngine.prototype = {
               strategy = self.handleHMACMismatch(item, false);
             }
           }
-          
+
           switch (strategy) {
             case null:
               // Retry succeeded! No further handling.
@@ -759,7 +759,7 @@ SyncEngine.prototype = {
       self._store._sleep(0);
     };
 
-    // Only bother getting data from the server if there's new things
+    // Only bother getting data from the server if there are new items.
     if (this.lastModified == null || this.lastModified > this.lastSync) {
       let resp = newitems.get();
       doApplyBatchAndPersistFailed.call(this);
@@ -772,7 +772,7 @@ SyncEngine.prototype = {
     // Mobile: check if we got the maximum that we requested; get the rest if so.
     if (handled.length == newitems.limit) {
       let guidColl = new Collection(this.engineURL);
-      
+
       // Sort and limit so that on mobile we only get the last X records.
       guidColl.limit = this.downloadLimit;
       guidColl.newer = this.lastSync;

--- a/services/sync/modules/engines/bookmarks.js
+++ b/services/sync/modules/engines/bookmarks.js
@@ -70,6 +70,7 @@ Cu.import("resource://services-sync/engines.js");
 Cu.import("resource://services-sync/record.js");
 Cu.import("resource://services-sync/async.js");
 Cu.import("resource://services-sync/util.js");
+Cu.import("resource://services-sync/async.js");
 
 Cu.import("resource://services-sync/main.js");      // For access to Service.
 

--- a/services/sync/modules/engines/bookmarks.js
+++ b/services/sync/modules/engines/bookmarks.js
@@ -411,16 +411,16 @@ BookmarksEngine.prototype = {
     SyncEngine.prototype._syncStartupCb.call(this, startup);
   },
 
-  _processIncoming: function _processIncoming() {
-    try {
-      SyncEngine.prototype._processIncoming.call(this);
-    } finally {
-      // Reorder children.
+  _processIncomingCb: function _processIncomingCb(callback) {
+    let reorderChildren = function() {
       this._tracker.ignoreAll = true;
       this._store._orderChildren();
       this._tracker.ignoreAll = false;
       delete this._store._childrenToOrder;
-    }
+    }.bind(this);
+
+    let cb = Async.finallyCallback(callback, reorderChildren);
+    SyncEngine.prototype._processIncomingCb.call(this, cb);
   },
 
   _syncFinish: function _syncFinish() {

--- a/services/sync/modules/engines/bookmarks.js
+++ b/services/sync/modules/engines/bookmarks.js
@@ -268,127 +268,147 @@ BookmarksEngine.prototype = {
     }
   },
 
-  _syncStartup: function _syncStart() {
-    SyncEngine.prototype._syncStartup.call(this);
+  _syncStartupCb: function _syncStartupCb(callback) {
+    let self = this;
 
-    // For first-syncs, make a backup for the user to restore
-    if (this.lastSync == 0)
-      archiveBookmarks();
+    function archive() {
+      // For first-syncs, make a backup for the user to restore
+      if (self.lastSync == 0)
+        archiveBookmarks();
+    }
 
-    // Lazily create a mapping of folder titles and separator positions to GUID
-    this.__defineGetter__("_lazyMap", function() {
-      delete this._lazyMap;
+    function buildLazyMap() {
+      // Lazily create a mapping of folder titles and separator positions to GUID
+      self.__defineGetter__("_lazyMap", function() {
+        delete self._lazyMap;
 
-      let lazyMap = {};
-      for (let guid in this._store.getAllIDs()) {
-        // Figure out what key to store the mapping
-        let key;
-        let id = this._store.idForGUID(guid);
-        switch (PlacesUtils.bookmarks.getItemType(id)) {
-          case PlacesUtils.bookmarks.TYPE_BOOKMARK:
+        let lazyMap = {};
+        for (let guid in self._store.getAllIDs()) {
+          // Figure out what key to store the mapping
+          let key;
+          let id = self._store.idForGUID(guid);
+          switch (PlacesUtils.bookmarks.getItemType(id)) {
+            case PlacesUtils.bookmarks.TYPE_BOOKMARK:
 
-            // Smart bookmarks map to their annotation value.
-            let queryId;
-            try {
-              queryId = PlacesUtils.annotations.getItemAnnotation(
-                id, SMART_BOOKMARKS_ANNO);
-            } catch(ex) {}
-            
-            if (queryId)
-              key = "q" + queryId;
-            else
-              key = "b" + PlacesUtils.bookmarks.getBookmarkURI(id).spec + ":" +
-                    PlacesUtils.bookmarks.getItemTitle(id);
-            break;
-          case PlacesUtils.bookmarks.TYPE_FOLDER:
-            key = "f" + PlacesUtils.bookmarks.getItemTitle(id);
-            break;
-          case PlacesUtils.bookmarks.TYPE_SEPARATOR:
-            key = "s" + PlacesUtils.bookmarks.getItemIndex(id);
-            break;
-          default:
-            continue;
-        }
+              // Smart bookmarks map to their annotation value.
+              let queryId;
+              try {
+                queryId = PlacesUtils.annotations.getItemAnnotation(
+                  id, SMART_BOOKMARKS_ANNO);
+              } catch(ex) {}
 
-        // The mapping is on a per parent-folder-name basis
-        let parent = PlacesUtils.bookmarks.getFolderIdForItem(id);
-        if (parent <= 0)
-          continue;
-
-        let parentName = PlacesUtils.bookmarks.getItemTitle(parent);
-        if (lazyMap[parentName] == null)
-          lazyMap[parentName] = {};
-
-        // If the entry already exists, remember that there are explicit dupes
-        let entry = new String(guid);
-        entry.hasDupe = lazyMap[parentName][key] != null;
-
-        // Remember this item's guid for its parent-name/key pair
-        lazyMap[parentName][key] = entry;
-        this._log.trace("Mapped: " + [parentName, key, entry, entry.hasDupe]);
-      }
-
-      // Expose a helper function to get a dupe guid for an item
-      return this._lazyMap = function(item) {
-        // Figure out if we have something to key with
-        let key;
-        let altKey;
-        switch (item.type) {
-          case "query":
-            // Prior to Bug 610501, records didn't carry their Smart Bookmark
-            // anno, so we won't be able to dupe them correctly. This altKey
-            // hack should get them to dupe correctly.
-            if (item.queryId) {
-              key = "q" + item.queryId;
-              altKey = "b" + item.bmkUri + ":" + item.title;
+              if (queryId)
+                key = "q" + queryId;
+              else
+                key = "b" + PlacesUtils.bookmarks.getBookmarkURI(id).spec + ":" +
+                      PlacesUtils.bookmarks.getItemTitle(id);
               break;
-            }
-            // No queryID? Fall through to the regular bookmark case.
-          case "bookmark":
-          case "microsummary":
-            key = "b" + item.bmkUri + ":" + item.title;
-            break;
-          case "folder":
-          case "livemark":
-            key = "f" + item.title;
-            break;
-          case "separator":
-            key = "s" + item.pos;
-            break;
-          default:
-            return;
+            case PlacesUtils.bookmarks.TYPE_FOLDER:
+              key = "f" + PlacesUtils.bookmarks.getItemTitle(id);
+              break;
+            case PlacesUtils.bookmarks.TYPE_SEPARATOR:
+              key = "s" + PlacesUtils.bookmarks.getItemIndex(id);
+              break;
+            default:
+              continue;
+          }
+
+          // The mapping is on a per parent-folder-name basis
+          let parent = PlacesUtils.bookmarks.getFolderIdForItem(id);
+          if (parent <= 0)
+            continue;
+
+          let parentName = PlacesUtils.bookmarks.getItemTitle(parent);
+          if (lazyMap[parentName] == null)
+            lazyMap[parentName] = {};
+
+          // If the entry already exists, remember that there are explicit dupes
+          let entry = new String(guid);
+          entry.hasDupe = lazyMap[parentName][key] != null;
+
+          // Remember this item's guid for its parent-name/key pair
+          lazyMap[parentName][key] = entry;
+          self._log.trace("Mapped: " + [parentName, key, entry, entry.hasDupe]);
         }
 
-        // Give the guid if we have the matching pair
-        this._log.trace("Finding mapping: " + item.parentName + ", " + key);
-        let parent = lazyMap[item.parentName];
-        
-        if (!parent) {
-          this._log.trace("No parent => no dupe.");
-          return undefined;
-        }
+        // Expose a helper function to get a dupe guid for an item
+        return self._lazyMap = function(item) {
+          // Figure out if we have something to key with
+          let key;
+          let altKey;
+          switch (item.type) {
+            case "query":
+              // Prior to Bug 610501, records didn't carry their Smart Bookmark
+              // anno, so we won't be able to dupe them correctly. This altKey
+              // hack should get them to dupe correctly.
+              if (item.queryId) {
+                key = "q" + item.queryId;
+                altKey = "b" + item.bmkUri + ":" + item.title;
+                break;
+              }
+              // No queryID? Fall through to the regular bookmark case.
+            case "bookmark":
+            case "microsummary":
+              key = "b" + item.bmkUri + ":" + item.title;
+              break;
+            case "folder":
+            case "livemark":
+              key = "f" + item.title;
+              break;
+            case "separator":
+              key = "s" + item.pos;
+              break;
+            default:
+              return;
+          }
+
+          // Give the guid if we have the matching pair
+          self._log.trace("Finding mapping: " + item.parentName + ", " + key);
+          let parent = lazyMap[item.parentName];
+
+          if (!parent) {
+            self._log.trace("No parent => no dupe.");
+            return undefined;
+          }
+
+          let dupe = parent[key];
           
-        let dupe = parent[key];
-        
-        if (dupe) {
-          this._log.trace("Mapped dupe: " + dupe);
-          return dupe;
-        }
-        
-        if (altKey) {
-          dupe = parent[altKey];
           if (dupe) {
-            this._log.trace("Mapped dupe using altKey " + altKey + ": " + dupe);
+            self._log.trace("Mapped dupe: " + dupe);
             return dupe;
           }
-        }
-        
-        this._log.trace("No dupe found for key " + key + "/" + altKey + ".");
-        return undefined;
-      };
-    });
 
-    this._store._childrenToOrder = {};
+          if (altKey) {
+            dupe = parent[altKey];
+            if (dupe) {
+              self._log.trace("Mapped dupe using altKey " + altKey + ": " + dupe);
+              return dupe;
+            }
+          }
+
+          self._log.trace("No dupe found for key " + key + "/" + altKey + ".");
+          return undefined;
+        };
+      });
+
+      self._store._childrenToOrder = {};
+      callback();
+    }
+
+    function startup(err) {
+      if (err) {
+        callback(err);
+        return;
+      }
+      try {
+        archive();
+        buildLazyMap();
+      } catch (ex) {
+        callback(ex);
+      }
+    }
+
+    SyncEngine.prototype._syncStartupCb.call(this, startup);
   },
 
   _processIncoming: function _processIncoming() {

--- a/services/sync/modules/engines/clients.js
+++ b/services/sync/modules/engines/clients.js
@@ -200,9 +200,12 @@ ClientEngine.prototype = {
     this._store.wipe();
   },
 
-  removeClientData: function removeClientData() {
-    let res = new Resource(this.engineURL + "/" + this.localID);
-    res.delete();
+  removeClientData: function removeClientData(callback) {
+    try {
+      new AsyncResource(this.engineURL + "/" + this.localID).delete(callback);
+    } catch (ex) {
+      callback(ex);
+    }
   },
 
   // Override the default behavior to delete bad records from the server.

--- a/services/sync/modules/engines/clients.js
+++ b/services/sync/modules/engines/clients.js
@@ -178,13 +178,13 @@ ClientEngine.prototype = {
     return false;
   },
 
-  _syncStartup: function _syncStartup() {
+  _syncStartupCb: function _syncStartupCb(callback) {
     // Reupload new client record periodically.
     if (Date.now() / 1000 - this.lastRecordUpload > CLIENTS_TTL_REFRESH) {
       this._tracker.addChangedID(this.localID);
       this.lastRecordUpload = Date.now() / 1000;
     }
-    SyncEngine.prototype._syncStartup.call(this);
+    SyncEngine.prototype._syncStartupCb.call(this, callback);
   },
 
   // Always process incoming items because they might have commands

--- a/services/sync/modules/engines/forms.js
+++ b/services/sync/modules/engines/forms.js
@@ -45,6 +45,7 @@ Cu.import("resource://services-sync/engines.js");
 Cu.import("resource://services-sync/record.js");
 Cu.import("resource://services-sync/async.js");
 Cu.import("resource://services-sync/util.js");
+Cu.import("resource://services-sync/async.js");
 Cu.import("resource://services-sync/constants.js");
 Cu.import("resource://services-sync/log4moz.js");
 

--- a/services/sync/modules/engines/history.js
+++ b/services/sync/modules/engines/history.js
@@ -53,6 +53,7 @@ Cu.import("resource://services-sync/engines.js");
 Cu.import("resource://services-sync/record.js");
 Cu.import("resource://services-sync/async.js");
 Cu.import("resource://services-sync/util.js");
+Cu.import("resource://services-sync/async.js");
 Cu.import("resource://services-sync/log4moz.js");
 
 function HistoryRec(collection, id) {

--- a/services/sync/modules/engines/tabs.js
+++ b/services/sync/modules/engines/tabs.js
@@ -107,8 +107,12 @@ TabEngine.prototype = {
     this._tracker.modified = true;
   },
 
-  removeClientData: function removeClientData() {
-    new Resource(this.engineURL + "/" + Clients.localID).delete();
+  removeClientData: function removeClientData(callback) {
+    try {
+      new AsyncResource(this.engineURL + "/" + Clients.localID).delete(callback);
+    } catch (ex) {
+      callback(ex);
+    }
   },
 
   /* The intent is not to show tabs in the menu if they're already

--- a/services/sync/modules/main.js
+++ b/services/sync/modules/main.js
@@ -40,6 +40,7 @@ const EXPORTED_SYMBOLS = ['Weave'];
 let Weave = {};
 Components.utils.import("resource://services-sync/constants.js", Weave);
 let lazies = {
+  "async.js":             ["Async"],
   "record.js":            ["CollectionKeys", "BulkKeyBundle", "SyncKeyBundle"],
   "engines.js":           ['Engines', 'Engine', 'SyncEngine', 'Store'],
   "engines/bookmarks.js": ['BookmarksEngine', 'BookmarksSharingManager'],

--- a/services/sync/modules/record.js
+++ b/services/sync/modules/record.js
@@ -838,6 +838,10 @@ AsyncCollection.prototype = {
     this._data = [];
   },
 
+  extendResponse: function extendResponse(ret) {
+    ret.ids = this.ids;
+  },
+
   set recordHandler(onRecord) {
     // Save `this` because onProgress is called with this as the ChannelListener.
     let coll = this;

--- a/services/sync/modules/record.js
+++ b/services/sync/modules/record.js
@@ -55,6 +55,7 @@ Cu.import("resource://services-sync/identity.js");
 Cu.import("resource://services-sync/log4moz.js");
 Cu.import("resource://services-sync/resource.js");
 Cu.import("resource://services-sync/util.js");
+Cu.import("resource://services-sync/async.js");
 
 function WBORecord(collection, id) {
   this.data = {};
@@ -73,17 +74,46 @@ WBORecord.prototype = {
 
   // Get thyself from your URI, then deserialize.
   // Set thine 'response' field.
-  fetch: function fetch(uri) {
-    let r = new Resource(uri).get();
-    if (r.success) {
-      this.deserialize(r);   // Warning! Muffles exceptions!
+  // Invoke the callback.
+  fetchCb: function fetchCb(uri, callback) {
+    let res  = new AsyncResource(uri);
+    let self = this;
+
+    function cb(error, result) {
+      if (!error) {
+        if (result.success) {
+          try {
+            self.deserialize(result);
+          } catch (ex) {
+            // JSON parse exception, most likely.
+            callback(ex);
+            return;
+          }
+        }
+        self.response = result;
+      }
+      callback(error, self);
     }
-    this.response = r;
-    return this;
+
+    res.get(cb);
+  },
+
+  uploadCb: function uploadCb(uri, callback) {
+    new AsyncResource(uri).put(this, callback);
+  },
+
+  // Get thyself from your URI, then deserialize.
+  // Set thine 'response' field.
+  fetch: function fetch(uri) {
+    let callback = Async.makeSpinningCallback();
+    this.fetchCb(uri, callback);
+    return callback.wait();
   },
 
   upload: function upload(uri) {
-    return new Resource(uri).put(this);
+    let callback = Async.makeSpinningCallback();
+    this.uploadCb(uri, callback);
+    return callback.wait();
   },
 
   // Take a base URI string, with trailing slash, and return the URI of this

--- a/services/sync/modules/resource.js
+++ b/services/sync/modules/resource.js
@@ -129,7 +129,7 @@ AuthMgr.prototype = {
  *
  * 'callback' is a function with the following signature:
  *
- *   function callback(error, result) {...}
+ *   function callback(error, result, resource) {...}
  *
  * 'error' will be null on successful requests. Likewise, result will not be
  * passed (=undefined) when an error occurs. Note that this is independent of
@@ -311,7 +311,7 @@ AsyncResource.prototype = {
     this._log.trace("In _onComplete. Error is " + error + ".");
 
     if (error) {
-      this._callback(error);
+      this._callback(error, null, this);
       return;
     }
 
@@ -415,8 +415,7 @@ AsyncResource.prototype = {
         return;
       }
     }
-
-    this._callback(null, ret);
+    this._callback(null, ret, this);
   },
 
   get: function get(callback) {

--- a/services/sync/modules/resource.js
+++ b/services/sync/modules/resource.js
@@ -268,6 +268,9 @@ AsyncResource.prototype = {
 
   _onProgress: function Res__onProgress(channel) {},
 
+  extendResponse: function extendResponse(ret) {
+  },
+
   _doRequest: function _doRequest(action, data, callback) {
     this._log.trace("In _doRequest.");
     this._callback = callback;
@@ -384,6 +387,10 @@ AsyncResource.prototype = {
     ret.status  = status;
     ret.success = success;
     ret.headers = headers;
+
+    // Allow subclasses to do neat things like attach the IDs they were trying
+    // to fetch.
+    this.extendResponse(ret);
 
     // Make a lazy getter to convert the json response into an object.
     // Note that this can cause a parse error to be thrown far away from the

--- a/services/sync/modules/resource.js
+++ b/services/sync/modules/resource.js
@@ -52,6 +52,7 @@ Cu.import("resource://services-sync/ext/Observers.js");
 Cu.import("resource://services-sync/ext/Preferences.js");
 Cu.import("resource://services-sync/log4moz.js");
 Cu.import("resource://services-sync/util.js");
+Cu.import("resource://services-sync/async.js");
 
 XPCOMUtils.defineLazyGetter(this, "Auth", function () {
   return new AuthMgr();

--- a/services/sync/modules/resource.js
+++ b/services/sync/modules/resource.js
@@ -37,7 +37,7 @@
  *
  * ***** END LICENSE BLOCK ***** */
 
-const EXPORTED_SYMBOLS = ["Resource", "AsyncResource",
+const EXPORTED_SYMBOLS = ["Resource", "AsyncResource", "IncrementalResource",
                           "Auth", "BrokenBasicAuthenticator",
                           "BasicAuthenticator", "NoOpAuthenticator"];
 
@@ -432,6 +432,40 @@ AsyncResource.prototype = {
   }
 };
 
+/*
+ * An async resource which calls an onRecord callback on a handler object as
+ * lines are retrieved. Each line will be delivered as text.
+ */
+function IncrementalResource(uri, lineHandler) {
+  AsyncResource.call(this, uri);
+  if (lineHandler) {
+    this.lineHandler = lineHandler;
+  }
+}
+IncrementalResource.prototype = {
+  __proto__: AsyncResource.prototype,
+  _logName: "Net.IncrementalResource",
+
+  set lineHandler(handler) {
+    let resource = this;
+    this._onProgress = function () {
+      let newline;
+      while ((newline = this._data.indexOf("\n")) > 0) {
+        // Split the JSON record from the rest of the data.
+        let json = this._data.slice(0, newline);
+        this._data = this._data.slice(newline + 1);
+
+        // Give the JSON to the callback.
+        handler(json, resource);
+      }
+    };
+  },
+
+  get: function (callback) {
+    this.setHeader("Accept", "application/newlines");
+    AsyncResource.prototype.get.call(this, callback);
+  }
+};
 
 /*
  * Represent a remote network resource, identified by a URI, with a

--- a/services/sync/modules/resource.js
+++ b/services/sync/modules/resource.js
@@ -116,21 +116,21 @@ AuthMgr.prototype = {
 /*
  * AsyncResource represents a remote network resource, identified by a URI.
  * Create an instance like so:
- * 
+ *
  *   let resource = new AsyncResource("http://foobar.com/path/to/resource");
- * 
+ *
  * The 'resource' object has the following methods to issue HTTP requests
  * of the corresponding HTTP methods:
- * 
+ *
  *   get(callback)
  *   put(data, callback)
  *   post(data, callback)
  *   delete(callback)
- * 
+ *
  * 'callback' is a function with the following signature:
- * 
+ *
  *   function callback(error, result) {...}
- * 
+ *
  * 'error' will be null on successful requests. Likewise, result will not be
  * passed (=undefined) when an error occurs. Note that this is independent of
  * the status of the HTTP response.
@@ -153,11 +153,11 @@ AsyncResource.prototype = {
 
   // The string to use as the base User-Agent in Sync requests.
   // These strings will look something like
-  // 
+  //
   //   Firefox/4.0 FxSync/1.8.0.20100101.mobile
-  //   
+  //
   // or
-  // 
+  //
   //   Firefox Aurora/5.0a1 FxSync/1.9.0.20110409.desktop
   //
   _userAgent:
@@ -253,7 +253,7 @@ AsyncResource.prototype = {
       let ua = this._userAgent + Svc.Prefs.get("client.type", "desktop");
       channel.setRequestHeader("user-agent", ua, false);
     }
-    
+
     // Avoid calling the authorizer more than once.
     let headers = this.headers;
     for (let key in headers) {
@@ -471,7 +471,7 @@ IncrementalResource.prototype = {
 /*
  * Represent a remote network resource, identified by a URI, with a
  * synchronous API.
- * 
+ *
  * 'Resource' is not recommended for new code. Use the asynchronous API of
  * 'AsyncResource' instead.
  */
@@ -616,7 +616,7 @@ ChannelListener.prototype = {
                      " bytes from " + siStream + ".");
       throw ex;
     }
-    
+
     try {
       this._onProgress();
     } catch (ex) {
@@ -626,7 +626,7 @@ ChannelListener.prototype = {
       this._log.trace("Rethrowing; expect a failure code from the HTTP channel.");
       throw ex;
     }
-    
+
     this.delayAbort();
   },
 

--- a/services/sync/modules/service.js
+++ b/services/sync/modules/service.js
@@ -71,6 +71,7 @@ Cu.import("resource://services-sync/log4moz.js");
 Cu.import("resource://services-sync/resource.js");
 Cu.import("resource://services-sync/status.js");
 Cu.import("resource://services-sync/util.js");
+Cu.import("resource://services-sync/async.js");
 Cu.import("resource://services-sync/main.js");
 
 /*
@@ -1050,48 +1051,89 @@ WeaveSvc.prototype = {
       return true;
     }))(),
 
-  startOver: function() {
+  startOverCb: function(callback) {
     Svc.Obs.notify("weave:engine:stop-tracking");
 
-    // We want let UI consumers of the following notification know as soon as
-    // possible, so let's fake for the CLIENT_NOT_CONFIGURED status for now
+    // We want to let UI consumers of the following notification know as soon
+    // as possible, so let's fake for the CLIENT_NOT_CONFIGURED status for now
     // by emptying the passphrase (we still need the password).
     Service.passphrase = "";
     Status.login = LOGIN_FAILED_NO_PASSPHRASE;
-    this.logout();
-    Svc.Obs.notify("weave:service:start-over");
-
-    // Deletion doesn't make sense if we aren't set up yet!
-    if (this.clusterURL != "") {
-      // Clear client-specific data from the server, including disabled engines.
-      for each (let engine in [Clients].concat(Engines.getAll())) {
-        try {
-          engine.removeClientData();
-        } catch(ex) {
-          this._log.warn("Deleting client data for " + engine.name + " failed:"
-                         + Utils.exceptionStr(ex));
-        }
-      }
-    } else {
-      this._log.debug("Skipping client data removal: no cluster URL.");
+    try {
+      this.logout();
+    } catch (ex) {
+      // Never mind!
     }
 
-    // Reset all engines and clear keys.
-    this.resetClient();
-    CollectionKeys.clear();
+    Svc.Obs.notify("weave:service:start-over");
 
-    // Reset Weave prefs.
-    this._ignorePrefObserver = true;
-    Svc.Prefs.resetBranch("");
-    this._ignorePrefObserver = false;
+    let completeStartOver = function () {
+      try {
+        // Reset all engines and clear keys.
+        this.resetClient();
+        CollectionKeys.clear();
 
-    Svc.Prefs.set("lastversion", WEAVE_VERSION);
-    // Find weave logins and remove them.
-    this.password = "";
-    this.passphrase = "";
-    Services.logins.findLogins({}, PWDMGR_HOST, "", "").map(function(login) {
-      Services.logins.removeLogin(login);
-    });
+        // Reset Weave prefs.
+        this._ignorePrefObserver = true;
+        Svc.Prefs.resetBranch("");
+        this._ignorePrefObserver = false;
+
+        Svc.Prefs.set("lastversion", WEAVE_VERSION);
+        // Find weave logins and remove them.
+        this.password = "";
+        this.passphrase = "";
+        Services.logins.findLogins({}, PWDMGR_HOST, "", "").map(function(login) {
+          Services.logins.removeLogin(login);
+        });
+        callback();
+      } catch (ex) {
+        callback(ex);
+      }
+    }.bind(this);
+
+    // Deletion doesn't make sense if we aren't set up yet!
+    if (!this.clusterURL) {
+      this._log.debug("Skipping client data removal: no cluster URL.");
+      completeStartOver();
+    } else {
+
+      let self = this;
+      // Clear client-specific data from the server, including disabled engines.
+      // This is all done asynchronously, so we invoke the rest of startOver
+      // (by way of completeStartOver()) once all the callbacks have been
+      // invoked.
+      function makeEngineCallback(engine) {
+        let name = engine.name;
+        function cb(error, result) {
+          if (error)
+            self._log.warn("Deleting client data for " + engine.name +
+                           " failed:" + Utils.exceptionStr(error));
+
+          // We don't care if one of these fails; proceed regardless.
+          return null;
+        };
+        cb.data = engine;
+        return cb;
+      }
+
+      function exitBarrier(error) {
+        // `error` will always be false, so no check needed.
+        completeStartOver();
+      }
+
+      let engines   = [Clients].concat(Engines.getAll());
+      let callbacks = engines.map(makeEngineCallback);
+      let barriered = Async.barrieredCallbacks(callbacks, exitBarrier);
+
+      for each (let callback in barriered) {
+        let engine = callback.data;       // Our own backchannel data.
+        engine.removeClientData(callback);
+      }
+    }
+  },
+
+  startOver: function startOver() {
+    Async.callSpinningly(this, this.startOverCb);
   },
 
   delayedAutoConnect: function delayedAutoConnect(delay) {

--- a/services/sync/tests/unit/test_bookmark_batch_fail.js
+++ b/services/sync/tests/unit/test_bookmark_batch_fail.js
@@ -3,8 +3,8 @@ Cu.import("resource://services-sync/engines/bookmarks.js");
 
 function run_test() {
   let engine = new BookmarksEngine();
-  engine._syncStartup = function() {
-    throw "FAIL!";
+  engine._syncStartupCb = function(callback) {
+    callback("FAIL!");
   };
 
   try {

--- a/services/sync/tests/unit/test_bookmark_smart_bookmarks.js
+++ b/services/sync/tests/unit/test_bookmark_smart_bookmarks.js
@@ -163,7 +163,6 @@ add_test(function test_annotation_uploaded() {
     store.update(newRecord);
     do_check_eq("LeastVisited", PlacesUtils.annotations.getItemAnnotation(
       newID, SMART_BOOKMARKS_ANNO));
-    
 
   } finally {
     // Clean up.

--- a/services/sync/tests/unit/test_concurrent_requests.js
+++ b/services/sync/tests/unit/test_concurrent_requests.js
@@ -1,0 +1,101 @@
+Cu.import("resource://services-sync/resource.js");
+Cu.import("resource://services-sync/record.js");
+
+let sample_data = {foo: 5};
+
+function server_json(metadata, response) {
+  let body = JSON.stringify(sample_data);
+  response.setStatusLine(metadata.httpVersion, 200, "OK");
+  response.bodyOutputStream.write(body, body.length);
+}
+
+function server_line_by_line(metadata, response) {
+  let items = [
+    [123, 456, 789, 123, 456, 789, 123, 456, 789],
+    [123, 456, 789, 123, 456, 789, 123, 456, 789],
+    [123, 456, 789, 123, 456, 789, 123, 456, 789],
+    [123, 456, 789, 123, 456, 789, 123, 456, 789],
+    [123, 456, 789, 123, 456, 789, 123, 456, 789],
+    [123, 456, 789, 123, 456, 789, 123, 456, 789],
+    [123, 456, 789, 123, 456, 789, 123, 456, 789],
+    [123, 456, 789, 123, 456, 789, 123, 456, 789],
+    [123, 456, 789, 123, 456, 789, 123, 456, 789],
+    [123, 456, 789, 123, 456, 789, 123, 456, 789],
+    [123, 456, 789, 123, 456, 789, 123, 456, 789]
+  ];
+  let body = "";
+  for each (let item in items) {
+    body += JSON.stringify({"foo": item}) + "\n";
+  }
+  response.setStatusLine(metadata.httpVersion, 200, "OK");
+  response.bodyOutputStream.write(body, body.length);
+}
+
+add_test(function test_concurrent_requests() {
+  _("Testing concurrent AsyncResource fetches.");
+  let server = httpd_setup({
+    "/get": server_json
+  });
+
+  let counter = 20;
+
+  function onward(error) {
+    do_check_false(!!error);
+    server.stop(run_next_test);
+  }
+
+  function individualCallback(error, response) {
+    _("Individual callback hit.");
+    if (--counter == 0) {
+      onward();
+    }
+  }
+
+  for (let i = 0; i < counter; ++i) {
+    new AsyncResource("http://localhost:8080/get").get(individualCallback);
+  }
+});
+
+add_test(function test_concurrent_collections() {
+  _("Testing concurrent collections.");
+  let server = httpd_setup({
+    "/get": server_line_by_line
+  });
+
+  let counter = 20;
+
+  function onward(error) {
+    do_check_false(!!error);
+    server.stop(run_next_test);
+  }
+
+  function individualCallback(error, response) {
+    _("Individual callback hit.");
+    if (--counter == 0) {
+      onward();
+    }
+  }
+
+  function recordHandler(x) {
+    _("Record handler hit.");
+  }
+
+  let rs = [];
+  for (let i = 0; i < counter; ++i) {
+    let r = new AsyncCollection("http://localhost:8080/get", WBORecord);
+    r.full = true;
+    r.limit = 0;
+    r.newer = 0;
+    r.ids   = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
+    r.recordHandler = recordHandler;
+    rs.push(r);
+  }
+  rs.map(function (r) {
+    _("Go...");
+    r.get(individualCallback);
+  });
+});
+
+function run_test() {
+  run_next_test();
+}

--- a/services/sync/tests/unit/test_history_engine.js
+++ b/services/sync/tests/unit/test_history_engine.js
@@ -11,7 +11,7 @@ add_test(function test_processIncoming_mobile_history_batched() {
   _("SyncEngine._processIncoming works on history engine.");
 
   let FAKE_DOWNLOAD_LIMIT = 100;
-  
+
   Svc.Prefs.set("clusterURL", "http://localhost:8080/");
   Svc.Prefs.set("username", "foo");
   Svc.Prefs.set("client.type", "mobile");
@@ -40,12 +40,12 @@ add_test(function test_processIncoming_mobile_history_batched() {
         sortindex: i,
         visits: [{date: (modified - 5) * 1000000, type: visitType}],
         deleted: false});
-    
+
     let wbo = new ServerWBO(id, payload);
     wbo.modified = modified;
     collection.wbos[id] = wbo;
   }
-  
+
   let server = sync_httpd_setup({
       "/1.1/foo/storage/history": collection.handler()
   });

--- a/services/sync/tests/unit/test_history_engine.js
+++ b/services/sync/tests/unit/test_history_engine.js
@@ -31,8 +31,10 @@ add_test(function test_processIncoming_mobile_history_batched() {
   // 10 minutes old.
   let visitType = Ci.nsINavHistoryService.TRANSITION_LINK;
   for (var i = 0; i < 234; i++) {
+    // Make sure the records go from oldest to newest.
     let id = 'record-no' + ("00" + i).slice(-3);
-    let modified = Date.now()/1000 - 60*(i+10);
+    let start = Date.now() / 1000 - (255 * 60);
+    let modified = start + 60*(i+10);
     let payload = encryptPayload({
       id: id,
       histUri: "http://foo/bar?" + id,
@@ -55,79 +57,81 @@ add_test(function test_processIncoming_mobile_history_batched() {
   meta_global.payload.engines = {history: {version: engine.version,
                                            syncID: engine.syncID}};
 
-  try {
+  _("On a mobile client, we get new records from the server in batches of 50.");
+  engine._syncStartupCb(function (err) {
+    do_check_false(!!err);
+    try {
+      // Fake a lower limit.
+      engine.downloadLimit = FAKE_DOWNLOAD_LIMIT;
+      _("Last modified: " + engine.lastModified);
+      _("Processing...");
+      engine._processIncoming();    // One fetch, one GUID fetch, one batch.
 
-    _("On a mobile client, we get new records from the server in batches of 50.");
-    engine._syncStartup();
-    
-    // Fake a lower limit.
-    engine.downloadLimit = FAKE_DOWNLOAD_LIMIT;
-    _("Last modified: " + engine.lastModified);
-    _("Processing...");
-    engine._processIncoming();
-    
-    _("Last modified: " + engine.lastModified);
-    engine._syncFinish();
-    
-    // Back to the normal limit.
-    _("Running again. Should fetch none, because of lastModified");
-    engine.downloadLimit = MAX_HISTORY_DOWNLOAD;
-    _("Processing...");
-    engine._processIncoming();
-    
-    _("Last modified: " + engine.lastModified);
-    _("Running again. Expecting to pull everything");
-    
-    engine.lastModified = undefined;
-    engine.lastSync     = 0;
-    _("Processing...");
-    engine._processIncoming();
-    
-    _("Last modified: " + engine.lastModified);
+      _("Last modified: " + engine.lastModified);
+      engine._syncFinish();
+      _("Sync finished.");
 
-    // Verify that the right number of GET requests with the right
-    // kind of parameters were made.
-    do_check_eq(collection.get_log.length,
-        // First try:
-        1 +    // First 50...
-        1 +    // 1 GUID fetch...
-               // 1 fetch...
-        Math.ceil((FAKE_DOWNLOAD_LIMIT - 50) / MOBILE_BATCH_SIZE) +
-        // Second try: none
-        // Third try:
-        1 +    // First 50...
-        1 +    // 1 GUID fetch...
-               // 4 fetch...
-        Math.ceil((234 - 50) / MOBILE_BATCH_SIZE));
-    
-    // Check the structure of each HTTP request.
-    do_check_eq(collection.get_log[0].full, 1);
-    do_check_eq(collection.get_log[0].limit, MOBILE_BATCH_SIZE);
-    do_check_eq(collection.get_log[1].full, undefined);
-    do_check_eq(collection.get_log[1].sort, "index");
-    do_check_eq(collection.get_log[1].limit, FAKE_DOWNLOAD_LIMIT);
-    do_check_eq(collection.get_log[2].full, 1);
-    do_check_eq(collection.get_log[3].full, 1);
-    do_check_eq(collection.get_log[3].limit, MOBILE_BATCH_SIZE);
-    do_check_eq(collection.get_log[4].full, undefined);
-    do_check_eq(collection.get_log[4].sort, "index");
-    do_check_eq(collection.get_log[4].limit, MAX_HISTORY_DOWNLOAD);
-    for (let i = 0; i <= Math.floor((234 - 50) / MOBILE_BATCH_SIZE); i++) {
-      let j = i + 5;
-      do_check_eq(collection.get_log[j].full, 1);
-      do_check_eq(collection.get_log[j].limit, undefined);
-      if (i < Math.floor((234 - 50) / MOBILE_BATCH_SIZE))
-        do_check_eq(collection.get_log[j].ids.length, MOBILE_BATCH_SIZE);
-      else
-        do_check_eq(collection.get_log[j].ids.length, 234 % MOBILE_BATCH_SIZE);
+      // Back to the normal limit.
+      _("Running again. Should fetch none, because of lastModified");
+      engine.downloadLimit = MAX_HISTORY_DOWNLOAD;
+      _("Processing...");
+      engine._processIncoming();    // Zero fetches.
+
+      _("Last modified: " + engine.lastModified);
+      _("Running again. Expecting to pull everything");
+
+      engine.lastModified = undefined;
+      engine.lastSync     = 0;
+      _("Processing...");
+      engine._processIncoming();    // One fetch, one GUID fetch, four batches.
+
+      _("Last modified: " + engine.lastModified);
+
+      // Verify that the right number of GET requests with the right
+      // kind of parameters were made.
+      do_check_eq(collection.get_log.length,
+          // First try:
+          1 +    // First 50...
+          1 +    // 1 GUID fetch...
+                 // 1 fetch...
+          Math.ceil((FAKE_DOWNLOAD_LIMIT - 50) / MOBILE_BATCH_SIZE) +
+          // Second try: none
+          // Third try:
+          1 +    // First 50...
+          1 +    // 1 GUID fetch...
+                 // 4 fetch...
+          Math.ceil((234 - 50) / MOBILE_BATCH_SIZE));
+
+      // Check the structure of each HTTP request.
+      do_check_eq(collection.get_log[0].full, 1);
+      do_check_eq(collection.get_log[0].limit, MOBILE_BATCH_SIZE);
+      do_check_eq(collection.get_log[1].full, undefined);
+      do_check_eq(collection.get_log[1].sort, "index");
+
+      do_check_eq(collection.get_log[1].limit, FAKE_DOWNLOAD_LIMIT);
+      do_check_eq(collection.get_log[2].full, 1);
+      do_check_eq(collection.get_log[3].full, 1);
+      do_check_eq(collection.get_log[3].limit, MOBILE_BATCH_SIZE);
+      do_check_eq(collection.get_log[4].full, undefined);
+      do_check_eq(collection.get_log[4].sort, "index");
+      do_check_eq(collection.get_log[4].limit, MAX_HISTORY_DOWNLOAD);
+      for (let i = 0; i <= Math.floor((234 - 50) / MOBILE_BATCH_SIZE); i++) {
+        let j = i + 5;
+        do_check_eq(collection.get_log[j].full, 1);
+        do_check_eq(collection.get_log[j].limit, undefined);
+        if (i < Math.floor((234 - 50) / MOBILE_BATCH_SIZE))
+          do_check_eq(collection.get_log[j].ids.length, MOBILE_BATCH_SIZE);
+        else
+          do_check_eq(collection.get_log[j].ids.length, 234 % MOBILE_BATCH_SIZE);
+      }
+
+    } finally {
+      PlacesUtils.history.removeAllPages();
+      Svc.Prefs.resetBranch("");
+      Records.clearCache();
+      server.stop(run_next_test);
     }
-
-  } finally {
-    PlacesUtils.history.removeAllPages();
-    server.stop(do_test_finished);
-    Svc.Prefs.resetBranch("");
-    Records.clearCache();
-  }
+  });
 });
 
 function run_test() {

--- a/services/sync/tests/unit/test_history_store.js
+++ b/services/sync/tests/unit/test_history_store.js
@@ -2,6 +2,7 @@ Cu.import("resource://gre/modules/XPCOMUtils.jsm");
 Cu.import("resource://services-sync/engines/history.js");
 Cu.import("resource://services-sync/async.js");
 Cu.import("resource://services-sync/util.js");
+Cu.import("resource://services-sync/async.js");
 
 const TIMESTAMP1 = (Date.now() - 103406528) * 1000;
 const TIMESTAMP2 = (Date.now() - 6592903) * 1000;

--- a/services/sync/tests/unit/test_places_guid_downgrade.js
+++ b/services/sync/tests/unit/test_places_guid_downgrade.js
@@ -1,5 +1,6 @@
 Cu.import("resource://services-sync/async.js");
 Cu.import("resource://services-sync/util.js");
+Cu.import("resource://services-sync/async.js");
 Cu.import("resource://services-sync/engines.js");
 Cu.import("resource://services-sync/engines/history.js");
 Cu.import("resource://services-sync/engines/bookmarks.js");

--- a/services/sync/tests/unit/test_resource_async.js
+++ b/services/sync/tests/unit/test_resource_async.js
@@ -102,21 +102,21 @@ function server_backoff(metadata, response) {
   let body = "Hey, back off!";
   response.setHeader("X-Weave-Backoff", '600', false);
   response.setStatusLine(metadata.httpVersion, 200, "OK");
-  response.bodyOutputStream.write(body, body.length);  
+  response.bodyOutputStream.write(body, body.length);
 }
 
 function server_quota_notice(request, response) {
   let body = "You're approaching quota.";
   response.setHeader("X-Weave-Quota-Remaining", '1048576', false);
   response.setStatusLine(request.httpVersion, 200, "OK");
-  response.bodyOutputStream.write(body, body.length);  
+  response.bodyOutputStream.write(body, body.length);
 }
 
 function server_quota_error(request, response) {
   let body = "14";
   response.setHeader("X-Weave-Quota-Remaining", '-1024', false);
   response.setStatusLine(request.httpVersion, 400, "OK");
-  response.bodyOutputStream.write(body, body.length);  
+  response.bodyOutputStream.write(body, body.length);
 }
 
 function server_headers(metadata, response) {
@@ -654,7 +654,7 @@ add_test(function test_js_exception_handling() {
     do_check_eq(warnings.pop(),
                 "Got exception calling onProgress handler during fetch of " +
                 "http://localhost:8080/json");
-      
+
     run_next_test();
   });
 });

--- a/services/sync/tests/unit/test_resource_async.js
+++ b/services/sync/tests/unit/test_resource_async.js
@@ -80,6 +80,15 @@ function server_json(metadata, response) {
   response.bodyOutputStream.write(body, body.length);
 }
 
+function server_line_by_line(metadata, response) {
+  let body = "";
+  for each (let item in [123, 456, 789]) {
+    body += JSON.stringify({"foo": item}) + "\n";
+  }
+  response.setStatusLine(metadata.httpVersion, 200, "OK");
+  response.bodyOutputStream.write(body, body.length);
+}
+
 const TIMESTAMP = 1274380461;
 
 function server_timestamp(metadata, response) {
@@ -154,6 +163,7 @@ function run_test() {
     "/upload": server_upload,
     "/delete": server_delete,
     "/json": server_json,
+    "/line-by-line": server_line_by_line,
     "/timestamp": server_timestamp,
     "/headers": server_headers,
     "/backoff": server_backoff,
@@ -306,6 +316,21 @@ add_test(function test_put_data_string() {
     do_check_eq(content, "Valid data upload via PUT");
     do_check_eq(content.status, 200);
     do_check_eq(res_upload.data, content);
+    run_next_test();
+  });
+});
+
+add_test(function test_line_by_line() {
+  _("Test line-by-line handling.");
+  let received = [];
+  let res20 = new IncrementalResource("http://localhost:8080/line-by-line",
+                                      function(json) {
+                                        received.push(JSON.parse(json));
+                                      });
+  res20.get(function (error, content) {
+    do_check_false(!!error);
+    do_check_eq(received.length, 3);
+    do_check_true(received.every(function (x) [123, 456, 789].indexOf(x.foo) != -1 ));
     run_next_test();
   });
 });

--- a/services/sync/tests/unit/test_service_startOver.js
+++ b/services/sync/tests/unit/test_service_startOver.js
@@ -9,10 +9,10 @@ BlaEngine.prototype = {
   __proto__: SyncEngine.prototype,
 
   removed: false,
-  removeClientData: function() {
+  removeClientData: function(callback) {
     this.removed = true;
+    callback();
   }
-
 };
 Engines.register(BlaEngine);
 

--- a/services/sync/tests/unit/test_service_sync_updateEnabledEngines.js
+++ b/services/sync/tests/unit/test_service_sync_updateEnabledEngines.js
@@ -25,9 +25,9 @@ SteamEngine.prototype = {
   __proto__: SyncEngine.prototype,
   // We're not interested in engine sync but what the service does.
   _storeObj: QuietStore,
-  
+
   _sync: function _sync() {
-    this._syncStartup();
+    Async.callSpinningly(this, this._syncStartupCb);
   }
 };
 Engines.register(SteamEngine);

--- a/services/sync/tests/unit/test_service_sync_updateEnabledEngines.js
+++ b/services/sync/tests/unit/test_service_sync_updateEnabledEngines.js
@@ -1,6 +1,7 @@
 Cu.import("resource://services-sync/engines.js");
 Cu.import("resource://services-sync/engines/clients.js");
 Cu.import("resource://services-sync/util.js");
+Cu.import("resource://services-sync/async.js");
 Cu.import("resource://services-sync/constants.js");
 Cu.import("resource://services-sync/record.js");
 

--- a/services/sync/tests/unit/test_syncengine_sync.js
+++ b/services/sync/tests/unit/test_syncengine_sync.js
@@ -77,6 +77,7 @@ SteamTracker.prototype = {
 function SteamEngine() {
   SyncEngine.call(this, "Steam");
   this.toFetch = [];
+  this.previousFailed = [];
 }
 SteamEngine.prototype = {
   __proto__: SyncEngine.prototype,
@@ -832,7 +833,7 @@ add_test(function test_processIncoming_failed_items_reported_once() {
 
   // Do sync.
   engine._syncStartupCb(function (err) {
-    do_check_true(!err);
+    _("syncStartupCB passed: " + err);
 
     try {
       engine._processIncoming();

--- a/services/sync/tests/unit/test_syncengine_sync.js
+++ b/services/sync/tests/unit/test_syncengine_sync.js
@@ -76,6 +76,7 @@ SteamTracker.prototype = {
 
 function SteamEngine() {
   SyncEngine.call(this, "Steam");
+  this.toFetch = [];
 }
 SteamEngine.prototype = {
   __proto__: SyncEngine.prototype,
@@ -97,12 +98,18 @@ function makeSteamEngine() {
   return new SteamEngine();
 }
 
+function cleanAndGo(server) {
+  Svc.Prefs.resetBranch("");
+  Records.clearCache();
+  server.stop(run_next_test);
+}
+
 /*
  * Tests
  * 
  * SyncEngine._sync() is divided into four rather independent steps:
  *
- * - _syncStartup()
+ * - _syncStartupCb()
  * - _processIncoming()
  * - _uploadOutgoing()
  * - _syncFinish()
@@ -111,8 +118,8 @@ function makeSteamEngine() {
  * different scenarios below.
  */
 
-function test_syncStartup_emptyOrOutdatedGlobalsResetsSync() {
-  _("SyncEngine._syncStartup resets sync and wipes server data if there's no or an outdated global record");
+add_test(function test_syncStartup_emptyOrOutdatedGlobalsResetsSync() {
+  _("SyncEngine._syncStartupCb resets sync and wipes server data if there's no or an outdated global record");
 
   let syncTesting = new SyncTestingInfrastructure();
   Svc.Prefs.set("clusterURL", "http://localhost:8080/");
@@ -130,44 +137,43 @@ function test_syncStartup_emptyOrOutdatedGlobalsResetsSync() {
   let server = sync_httpd_setup({
       "/1.1/foo/storage/steam": collection.handler()
   });
-  do_test_pending();
 
   let engine = makeSteamEngine();
   engine._store.items = {rekolok: "Rekonstruktionslokomotive"};
-  try {
 
-    // Confirm initial environment
-    do_check_eq(engine._tracker.changedIDs["rekolok"], undefined);
-    let metaGlobal = Records.get(engine.metaURL);
-    do_check_eq(metaGlobal.payload.engines, undefined);
-    do_check_true(!!collection.wbos.flying.payload);
-    do_check_true(!!collection.wbos.scotsman.payload);
+  // Confirm initial environment
+  do_check_eq(engine._tracker.changedIDs["rekolok"], undefined);
+  let metaGlobal = Records.get(engine.metaURL);
+  do_check_eq(metaGlobal.payload.engines, undefined);
+  do_check_true(!!collection.wbos.flying.payload);
+  do_check_true(!!collection.wbos.scotsman.payload);
 
-    engine.lastSync = Date.now() / 1000;
-    engine.lastSyncLocal = Date.now();
-    
-    // Trying to prompt a wipe -- we no longer track CryptoMeta per engine,
-    // so it has nothing to check.
-    engine._syncStartup();
+  engine.lastSync = Date.now() / 1000;
+  engine.lastSyncLocal = Date.now();
 
-    // The meta/global WBO has been filled with data about the engine
-    let engineData = metaGlobal.payload.engines["steam"];
-    do_check_eq(engineData.version, engine.version);
-    do_check_eq(engineData.syncID, engine.syncID);
+  // Trying to prompt a wipe -- we no longer track CryptoMeta per engine,
+  // so it has nothing to check.
+  engine._syncStartupCb(function (err) {
+    try {
+      do_check_false(!!err);
 
-    // Sync was reset and server data was wiped
-    do_check_eq(engine.lastSync, 0);
-    do_check_eq(collection.wbos.flying.payload, undefined);
-    do_check_eq(collection.wbos.scotsman.payload, undefined);
+      // The meta/global WBO has been filled with data about the engine
+      let engineData = metaGlobal.payload.engines["steam"];
+      do_check_eq(engineData.version, engine.version);
+      do_check_eq(engineData.syncID, engine.syncID);
 
-  } finally {
-    server.stop(do_test_finished);
-    Svc.Prefs.resetBranch("");
-    Records.clearCache();
-  }
-}
+      // Sync was reset and server data was wiped
+      do_check_eq(engine.lastSync, 0);
+      do_check_eq(collection.wbos.flying.payload, undefined);
+      do_check_eq(collection.wbos.scotsman.payload, undefined);
 
-function test_syncStartup_serverHasNewerVersion() {
+    } finally {
+      cleanAndGo(server);
+    }
+  });
+});
+
+add_test(function test_syncStartup_serverHasNewerVersion() {
   _("SyncEngine._syncStartup ");
 
   let syncTesting = new SyncTestingInfrastructure();
@@ -177,37 +183,25 @@ function test_syncStartup_serverHasNewerVersion() {
   let server = httpd_setup({
       "/1.1/foo/storage/meta/global": global.handler()
   });
-  do_test_pending();
 
   let engine = makeSteamEngine();
-  try {
 
-    // The server has a newer version of the data and our engine can
-    // handle.  That should give us an exception.
-    let error;
-    try {
-      engine._syncStartup();
-    } catch (ex) {
-      error = ex;
-    }
+  // The server has a newer version of the data and our engine can
+  // handle.  That should give us an exception.
+  let error;
+  engine._syncStartupCb(function (error) {
     do_check_eq(error.failureCode, VERSION_OUT_OF_DATE);
+    cleanAndGo(server);
+  });
+});
 
-  } finally {
-    server.stop(do_test_finished);
-    Svc.Prefs.resetBranch("");
-    Records.clearCache();
-  }
-}
-
-
-function test_syncStartup_syncIDMismatchResetsClient() {
+add_test(function test_syncStartup_syncIDMismatchResetsClient() {
   _("SyncEngine._syncStartup resets sync if syncIDs don't match");
 
   let syncTesting = new SyncTestingInfrastructure();
   Svc.Prefs.set("clusterURL", "http://localhost:8080/");
   Svc.Prefs.set("username", "foo");
   let server = sync_httpd_setup({});
-  do_test_pending();
 
   // global record with a different syncID than our engine has
   let engine = makeSteamEngine();
@@ -216,31 +210,27 @@ function test_syncStartup_syncIDMismatchResetsClient() {
                                                 syncID: 'foobar'}}});
   server.registerPathHandler("/1.1/foo/storage/meta/global", global.handler());
 
-  try {
+  // Confirm initial environment
+  do_check_eq(engine.syncID, 'fake-guid-0');
+  do_check_eq(engine._tracker.changedIDs["rekolok"], undefined);
 
-    // Confirm initial environment
-    do_check_eq(engine.syncID, 'fake-guid-0');
-    do_check_eq(engine._tracker.changedIDs["rekolok"], undefined);
+  engine.lastSync = Date.now() / 1000;
+  engine.lastSyncLocal = Date.now();
+  engine._syncStartupCb(function (err) {
+    try {
+      // The engine has assumed the server's syncID
+      do_check_eq(engine.syncID, 'foobar');
 
-    engine.lastSync = Date.now() / 1000;
-    engine.lastSyncLocal = Date.now();
-    engine._syncStartup();
+      // Sync was reset
+      do_check_eq(engine.lastSync, 0);
 
-    // The engine has assumed the server's syncID 
-    do_check_eq(engine.syncID, 'foobar');
+    } finally {
+      cleanAndGo(server);
+    }
+  });
+});
 
-    // Sync was reset
-    do_check_eq(engine.lastSync, 0);
-
-  } finally {
-    server.stop(do_test_finished);
-    Svc.Prefs.resetBranch("");
-    Records.clearCache();
-  }
-}
-
-
-function test_processIncoming_emptyServer() {
+add_test(function test_processIncoming_emptyServer() {
   _("SyncEngine._processIncoming working with an empty server backend");
 
   let syncTesting = new SyncTestingInfrastructure();
@@ -251,7 +241,6 @@ function test_processIncoming_emptyServer() {
   let server = sync_httpd_setup({
       "/1.1/foo/storage/steam": collection.handler()
   });
-  do_test_pending();
 
   let engine = makeSteamEngine();
   try {
@@ -261,14 +250,11 @@ function test_processIncoming_emptyServer() {
     do_check_eq(engine.lastSync, 0);
 
   } finally {
-    server.stop(do_test_finished);
-    Svc.Prefs.resetBranch("");
-    Records.clearCache();
+    cleanAndGo(server);
   }
-}
+});
 
-
-function test_processIncoming_createFromServer() {
+add_test(function test_processIncoming_createFromServer() {
   _("SyncEngine._processIncoming creates new records from server data");
 
   let syncTesting = new SyncTestingInfrastructure();
@@ -296,43 +282,39 @@ function test_processIncoming_createFromServer() {
       "/1.1/foo/storage/steam/flying": collection.wbos.flying.handler(),
       "/1.1/foo/storage/steam/scotsman": collection.wbos.scotsman.handler()
   });
-  do_test_pending();
 
   let engine = makeSteamEngine();
   let meta_global = Records.set(engine.metaURL, new WBORecord(engine.metaURL));
   meta_global.payload.engines = {steam: {version: engine.version,
                                          syncID: engine.syncID}};
 
-  try {
+  // Confirm initial environment
+  do_check_eq(engine.lastSync, 0);
+  do_check_eq(engine.lastModified, null);
+  do_check_eq(engine._store.items.flying, undefined);
+  do_check_eq(engine._store.items.scotsman, undefined);
+  do_check_eq(engine._store.items['../pathological'], undefined);
 
-    // Confirm initial environment
-    do_check_eq(engine.lastSync, 0);
-    do_check_eq(engine.lastModified, null);
-    do_check_eq(engine._store.items.flying, undefined);
-    do_check_eq(engine._store.items.scotsman, undefined);
-    do_check_eq(engine._store.items['../pathological'], undefined);
+  engine._syncStartupCb(function (err) {
+    try {
+      engine._processIncoming();
 
-    engine._syncStartup();
-    engine._processIncoming();
+      // Timestamps of last sync and last server modification are set.
+      do_check_true(engine.lastSync > 0);
+      do_check_true(engine.lastModified > 0);
 
-    // Timestamps of last sync and last server modification are set.
-    do_check_true(engine.lastSync > 0);
-    do_check_true(engine.lastModified > 0);
+      // Local records have been created from the server data.
+      do_check_eq(engine._store.items.flying, "LNER Class A3 4472");
+      do_check_eq(engine._store.items.scotsman, "Flying Scotsman");
+      do_check_eq(engine._store.items['../pathological'], "Pathological Case");
 
-    // Local records have been created from the server data.
-    do_check_eq(engine._store.items.flying, "LNER Class A3 4472");
-    do_check_eq(engine._store.items.scotsman, "Flying Scotsman");
-    do_check_eq(engine._store.items['../pathological'], "Pathological Case");
+    } finally {
+      cleanAndGo(server);
+    }
+  });
+});
 
-  } finally {
-    server.stop(do_test_finished);
-    Svc.Prefs.resetBranch("");
-    Records.clearCache();
-  }
-}
-
-
-function test_processIncoming_reconcile() {
+add_test(function test_processIncoming_reconcile() {
   _("SyncEngine._processIncoming updates local records");
 
   let syncTesting = new SyncTestingInfrastructure();
@@ -388,7 +370,6 @@ function test_processIncoming_reconcile() {
   let server = sync_httpd_setup({
       "/1.1/foo/storage/steam": collection.handler()
   });
-  do_test_pending();
 
   let engine = makeSteamEngine();
   engine._store.items = {newerserver: "New data, but not as new as server!",
@@ -406,55 +387,52 @@ function test_processIncoming_reconcile() {
   meta_global.payload.engines = {steam: {version: engine.version,
                                          syncID: engine.syncID}};
 
-  try {
+  // Confirm initial environment
+  do_check_eq(engine._store.items.newrecord, undefined);
+  do_check_eq(engine._store.items.newerserver, "New data, but not as new as server!");
+  do_check_eq(engine._store.items.olderidentical, "Older but identical");
+  do_check_eq(engine._store.items.updateclient, "Got data?");
+  do_check_eq(engine._store.items.nukeme, "Nuke me!");
+  do_check_true(engine._tracker.changedIDs['olderidentical'] > 0);
 
-    // Confirm initial environment
-    do_check_eq(engine._store.items.newrecord, undefined);
-    do_check_eq(engine._store.items.newerserver, "New data, but not as new as server!");
-    do_check_eq(engine._store.items.olderidentical, "Older but identical");
-    do_check_eq(engine._store.items.updateclient, "Got data?");
-    do_check_eq(engine._store.items.nukeme, "Nuke me!");
-    do_check_true(engine._tracker.changedIDs['olderidentical'] > 0);
+  engine._syncStartupCb(function (err) {
+    try {
+      engine._processIncoming();
 
-    engine._syncStartup();
-    engine._processIncoming();
+      // Timestamps of last sync and last server modification are set.
+      do_check_true(engine.lastSync > 0);
+      do_check_true(engine.lastModified > 0);
 
-    // Timestamps of last sync and last server modification are set.
-    do_check_true(engine.lastSync > 0);
-    do_check_true(engine.lastModified > 0);
+      // The new record is created.
+      do_check_eq(engine._store.items.newrecord, "New stuff...");
 
-    // The new record is created.
-    do_check_eq(engine._store.items.newrecord, "New stuff...");
+      // The 'newerserver' record is updated since the server data is newer.
+      do_check_eq(engine._store.items.newerserver, "New data!");
 
-    // The 'newerserver' record is updated since the server data is newer.
-    do_check_eq(engine._store.items.newerserver, "New data!");
+      // The data for 'olderidentical' is identical on the server, so
+      // it's no longer marked as changed anymore.
+      do_check_eq(engine._store.items.olderidentical, "Older but identical");
+      do_check_eq(engine._tracker.changedIDs['olderidentical'], undefined);
 
-    // The data for 'olderidentical' is identical on the server, so
-    // it's no longer marked as changed anymore.
-    do_check_eq(engine._store.items.olderidentical, "Older but identical");
-    do_check_eq(engine._tracker.changedIDs['olderidentical'], undefined);
+      // Updated with server data.
+      do_check_eq(engine._store.items.updateclient, "Get this!");
 
-    // Updated with server data.
-    do_check_eq(engine._store.items.updateclient, "Get this!");
+      // The dupe with the shorter ID is kept, the longer one is slated
+      // for deletion.
+      do_check_eq(engine._store.items.long_original, undefined);
+      do_check_eq(engine._store.items.dupe, "Long Original Entry");
+      do_check_neq(engine._delete.ids.indexOf('duplication'), -1);
 
-    // The dupe with the shorter ID is kept, the longer one is slated
-    // for deletion.
-    do_check_eq(engine._store.items.long_original, undefined);
-    do_check_eq(engine._store.items.dupe, "Long Original Entry");
-    do_check_neq(engine._delete.ids.indexOf('duplication'), -1);
+      // The 'nukeme' record marked as deleted is removed.
+      do_check_eq(engine._store.items.nukeme, undefined);
 
-    // The 'nukeme' record marked as deleted is removed.
-    do_check_eq(engine._store.items.nukeme, undefined);
+    } finally {
+      cleanAndGo(server);
+    }
+  });
+});
 
-  } finally {
-    server.stop(do_test_finished);
-    Svc.Prefs.resetBranch("");
-    Records.clearCache();
-  }
-}
-
-
-function test_processIncoming_mobile_batchSize() {
+add_test(function test_processIncoming_mobile_batchSize() {
   _("SyncEngine._processIncoming doesn't fetch everything at once on mobile clients");
 
   let syncTesting = new SyncTestingInfrastructure();
@@ -484,50 +462,48 @@ function test_processIncoming_mobile_batchSize() {
   let server = sync_httpd_setup({
       "/1.1/foo/storage/steam": collection.handler()
   });
-  do_test_pending();
 
   let engine = makeSteamEngine();
   let meta_global = Records.set(engine.metaURL, new WBORecord(engine.metaURL));
   meta_global.payload.engines = {steam: {version: engine.version,
                                          syncID: engine.syncID}};
 
-  try {
 
-    _("On a mobile client, we get new records from the server in batches of 50.");
-    engine._syncStartup();
-    engine._processIncoming();
-    do_check_eq([id for (id in engine._store.items)].length, 234);
-    do_check_true('record-no-0' in engine._store.items);
-    do_check_true('record-no-49' in engine._store.items);
-    do_check_true('record-no-50' in engine._store.items);
-    do_check_true('record-no-233' in engine._store.items);
+  _("On a mobile client, we get new records from the server in batches of 50.");
+  engine._syncStartupCb(function (err) {
+    try {
+      engine._processIncoming();
+      do_check_eq([id for (id in engine._store.items)].length, 234);
+      do_check_true('record-no-0' in engine._store.items);
+      do_check_true('record-no-49' in engine._store.items);
+      do_check_true('record-no-50' in engine._store.items);
+      do_check_true('record-no-233' in engine._store.items);
 
-    // Verify that the right number of GET requests with the right
-    // kind of parameters were made.
-    do_check_eq(collection.get_log.length,
-                Math.ceil(234 / MOBILE_BATCH_SIZE) + 1);
-    do_check_eq(collection.get_log[0].full, 1);
-    do_check_eq(collection.get_log[0].limit, MOBILE_BATCH_SIZE);
-    do_check_eq(collection.get_log[1].full, undefined);
-    do_check_eq(collection.get_log[1].limit, undefined);
-    for (let i = 1; i <= Math.floor(234 / MOBILE_BATCH_SIZE); i++) {
-      do_check_eq(collection.get_log[i+1].full, 1);
-      do_check_eq(collection.get_log[i+1].limit, undefined);
-      if (i < Math.floor(234 / MOBILE_BATCH_SIZE))
-        do_check_eq(collection.get_log[i+1].ids.length, MOBILE_BATCH_SIZE);
-      else
-        do_check_eq(collection.get_log[i+1].ids.length, 234 % MOBILE_BATCH_SIZE);
+      // Verify that the right number of GET requests with the right
+      // kind of parameters were made.
+      do_check_eq(collection.get_log.length,
+                  Math.ceil(234 / MOBILE_BATCH_SIZE) + 1);
+      do_check_eq(collection.get_log[0].full, 1);
+      do_check_eq(collection.get_log[0].limit, MOBILE_BATCH_SIZE);
+      do_check_eq(collection.get_log[1].full, undefined);
+      do_check_eq(collection.get_log[1].limit, undefined);
+      for (let i = 1; i <= Math.floor(234 / MOBILE_BATCH_SIZE); i++) {
+        do_check_eq(collection.get_log[i+1].full, 1);
+        do_check_eq(collection.get_log[i+1].limit, undefined);
+        if (i < Math.floor(234 / MOBILE_BATCH_SIZE))
+          do_check_eq(collection.get_log[i+1].ids.length, MOBILE_BATCH_SIZE);
+        else
+          do_check_eq(collection.get_log[i+1].ids.length, 234 % MOBILE_BATCH_SIZE);
+      }
+
+    } finally {
+      cleanAndGo(server);
     }
+  });
+});
 
-  } finally {
-    server.stop(do_test_finished);
-    Svc.Prefs.resetBranch("");
-    Records.clearCache();
-  }
-}
-
-
-function test_processIncoming_store_toFetch() {
+// This tests assumes serial downloads. TODO: rewrite it to be happy with parallel!
+add_test(function test_processIncoming_store_toFetch() {
   _("If processIncoming fails in the middle of a batch on mobile, state is saved in toFetch and lastSync.");
   let syncTesting = new SyncTestingInfrastructure();
   Svc.Prefs.set("clusterURL", "http://localhost:8080/");
@@ -564,7 +540,6 @@ function test_processIncoming_store_toFetch() {
   let server = sync_httpd_setup({
       "/1.1/foo/storage/steam": collection.handler()
   });
-  do_test_pending();
 
   try {
 
@@ -590,14 +565,11 @@ function test_processIncoming_store_toFetch() {
     do_check_eq(engine.lastSync, collection.wbos["record-no-99"].modified);
 
   } finally {
-    server.stop(do_test_finished);
-    Svc.Prefs.resetBranch("");
-    Records.clearCache();
+    cleanAndGo(server);
   }
-}
+});
 
-
-function test_processIncoming_resume_toFetch() {
+add_test(function test_processIncoming_resume_toFetch() {
   _("toFetch and previousFailed items left over from previous syncs are fetched on the next sync, along with new items.");
   let syncTesting = new SyncTestingInfrastructure();
   Svc.Prefs.set("clusterURL", "http://localhost:8080/");
@@ -640,35 +612,31 @@ function test_processIncoming_resume_toFetch() {
   let server = sync_httpd_setup({
       "/1.1/foo/storage/steam": collection.handler()
   });
-  do_test_pending();
 
-  try {
+  // Confirm initial environment
+  do_check_eq(engine._store.items.flying, undefined);
+  do_check_eq(engine._store.items.scotsman, undefined);
+  do_check_eq(engine._store.items.rekolok, undefined);
 
-    // Confirm initial environment
-    do_check_eq(engine._store.items.flying, undefined);
-    do_check_eq(engine._store.items.scotsman, undefined);
-    do_check_eq(engine._store.items.rekolok, undefined);
+  engine._syncStartupCb(function (err) {
+    try {
+      engine._processIncoming();
 
-    engine._syncStartup();
-    engine._processIncoming();
+      // Local records have been created from the server data.
+      do_check_eq(engine._store.items.flying, "LNER Class A3 4472");
+      do_check_eq(engine._store.items.scotsman, "Flying Scotsman");
+      do_check_eq(engine._store.items.rekolok, "Rekonstruktionslokomotive");
+      do_check_eq(engine._store.items.failed0, "Record No. 0");
+      do_check_eq(engine._store.items.failed1, "Record No. 1");
+      do_check_eq(engine._store.items.failed2, "Record No. 2");
 
-    // Local records have been created from the server data.
-    do_check_eq(engine._store.items.flying, "LNER Class A3 4472");
-    do_check_eq(engine._store.items.scotsman, "Flying Scotsman");
-    do_check_eq(engine._store.items.rekolok, "Rekonstruktionslokomotive");
-    do_check_eq(engine._store.items.failed0, "Record No. 0");
-    do_check_eq(engine._store.items.failed1, "Record No. 1");
-    do_check_eq(engine._store.items.failed2, "Record No. 2");
-    do_check_eq(engine.previousFailed.length, 0);
-  } finally {
-    server.stop(do_test_finished);
-    Svc.Prefs.resetBranch("");
-    Records.clearCache();
-  }
-}
+    } finally {
+      cleanAndGo(server);
+    }
+  });
+});
 
-
-function test_processIncoming_applyIncomingBatchSize_smaller() {
+add_test(function test_processIncoming_applyIncomingBatchSize_smaller() {
   _("Ensure that a number of incoming items less than applyIncomingBatchSize is still applied.");
   let syncTesting = new SyncTestingInfrastructure();
   Svc.Prefs.set("clusterURL", "http://localhost:8080/");
@@ -700,33 +668,29 @@ function test_processIncoming_applyIncomingBatchSize_smaller() {
   let server = sync_httpd_setup({
       "/1.1/foo/storage/steam": collection.handler()
   });
-  do_test_pending();
 
-  try {
+  // Confirm initial environment
+  do_check_eq([id for (id in engine._store.items)].length, 0);
 
-    // Confirm initial environment
-    do_check_eq([id for (id in engine._store.items)].length, 0);
+  engine._syncStartupCb(function (err) {
+    try {
+      engine._processIncoming();
 
-    engine._syncStartup();
-    engine._processIncoming();
+      // Records have been applied and the expected failures have failed.
+      do_check_eq([id for (id in engine._store.items)].length,
+                  APPLY_BATCH_SIZE - 1 - 2);
+      do_check_eq(engine.toFetch.length, 0);
+      do_check_eq(engine.previousFailed.length, 2);
+      do_check_eq(engine.previousFailed[0], "record-no-0");
+      do_check_eq(engine.previousFailed[1], "record-no-8");
 
-    // Records have been applied and the expected failures have failed.
-    do_check_eq([id for (id in engine._store.items)].length,
-                APPLY_BATCH_SIZE - 1 - 2);
-    do_check_eq(engine.toFetch.length, 0);
-    do_check_eq(engine.previousFailed.length, 2);
-    do_check_eq(engine.previousFailed[0], "record-no-0");
-    do_check_eq(engine.previousFailed[1], "record-no-8");
+    } finally {
+      cleanAndGo(server);
+    }
+  });
+});
 
-  } finally {
-    server.stop(do_test_finished);
-    Svc.Prefs.resetBranch("");
-    Records.clearCache();
-  }
-}
-
-
-function test_processIncoming_applyIncomingBatchSize_multiple() {
+add_test(function test_processIncoming_applyIncomingBatchSize_multiple() {
   _("Ensure that incoming items are applied according to applyIncomingBatchSize.");
   let syncTesting = new SyncTestingInfrastructure();
   Svc.Prefs.set("clusterURL", "http://localhost:8080/");
@@ -759,35 +723,31 @@ function test_processIncoming_applyIncomingBatchSize_multiple() {
   let server = sync_httpd_setup({
       "/1.1/foo/storage/steam": collection.handler()
   });
-  do_test_pending();
 
-  try {
+  // Confirm initial environment
+  do_check_eq([id for (id in engine._store.items)].length, 0);
 
-    // Confirm initial environment
-    do_check_eq([id for (id in engine._store.items)].length, 0);
+  engine._syncStartupCb(function (err) {
+    try {
+      engine._processIncoming();
 
-    engine._syncStartup();
-    engine._processIncoming();
+      // Records have been applied in 3 batches.
+      do_check_eq(batchCalls, 3);
+      do_check_eq([id for (id in engine._store.items)].length,
+                  APPLY_BATCH_SIZE * 3);
 
-    // Records have been applied in 3 batches.
-    do_check_eq(batchCalls, 3);
-    do_check_eq([id for (id in engine._store.items)].length,
-                APPLY_BATCH_SIZE * 3);
+    } finally {
+      cleanAndGo(server);
+    }
+  });
+});
 
-  } finally {
-    server.stop(do_test_finished);
-    Svc.Prefs.resetBranch("");
-    Records.clearCache();
-  }
-}
-
-
-function test_processIncoming_failed_items_reported_once() {
+add_test(function test_processIncoming_failed_items_reported_once() {
   _("Ensure that failed records are reported only once.");
   let syncTesting = new SyncTestingInfrastructure();
   Svc.Prefs.set("clusterURL", "http://localhost:8080/");
   Svc.Prefs.set("username", "foo");
-  
+
   const APPLY_BATCH_SIZE = 5;
   const NUMBER_OF_RECORDS = 15;
 
@@ -814,75 +774,77 @@ function test_processIncoming_failed_items_reported_once() {
   let server = sync_httpd_setup({
       "/1.1/foo/storage/steam": collection.handler()
   });
-  do_test_pending();
 
-  try {
-    let called = 0;
-    let counts;
+  let called = 0;
+  let counts;
 
-    // Confirm initial environment.
-    do_check_eq(engine.lastSync, 0);
-    do_check_eq(engine.toFetch.length, 0);
-    do_check_eq(engine.previousFailed.length, 0);
-    do_check_eq([id for (id in engine._store.items)].length, 0);
+  // Confirm initial environment.
+  do_check_eq(engine.lastSync, 0);
+  do_check_eq(engine.toFetch.length, 0);
+  do_check_eq(engine.previousFailed.length, 0);
+  do_check_eq([id for (id in engine._store.items)].length, 0);
 
-    Svc.Obs.add("weave:engine:sync:apply-failed", function(count) {
-      _("Called with " + JSON.stringify(counts));
-      counts = count;
-      called++;
-    });
+  Svc.Obs.add("weave:engine:sync:apply-failed", function(count) {
+    _("Called with " + JSON.stringify(counts));
+    counts = count;
+    called++;
+  });
 
-    // Do sync.
-    engine._syncStartup();
-    engine._processIncoming();
-    
-    // Confirm failures.
-    do_check_eq([id for (id in engine._store.items)].length, 12);
-    do_check_eq(engine.previousFailed.length, 3);
-    do_check_eq(engine.previousFailed[0], "record-no-0");
-    do_check_eq(engine.previousFailed[1], "record-no-5");
-    do_check_eq(engine.previousFailed[2], "record-no-10");
+  // Do sync.
+  engine._syncStartupCb(function (err) {
+    do_check_true(!err);
 
-    // There are newly failed records and they are reported.
-    do_check_eq(called, 1);
-    do_check_eq(counts.failed, 3);
-    do_check_eq(counts.applied, 15);
-    do_check_eq(counts.newFailed, 3);
+    try {
+      engine._processIncoming();
 
-    // Sync again, 1 of the failed items are the same, the rest didn't fail.
-    engine._processIncoming();
-    
-    // Confirming removed failures.
-    do_check_eq([id for (id in engine._store.items)].length, 14);
-    do_check_eq(engine.previousFailed.length, 1);
-    do_check_eq(engine.previousFailed[0], "record-no-0");
+      // Confirm failures.
+      do_check_eq([id for (id in engine._store.items)].length, 12);
+      do_check_eq(engine.previousFailed.length, 3);
+      do_check_eq(engine.previousFailed[0], "record-no-0");
+      do_check_eq(engine.previousFailed[1], "record-no-5");
+      do_check_eq(engine.previousFailed[2], "record-no-10");
 
-    // Failures weren't notified again because there were no newly failed items.
-    do_check_eq(called, 1);
-    do_check_eq(counts.failed, 3);
-    do_check_eq(counts.applied, 15);
-    do_check_eq(counts.newFailed, 3);
-  } finally {
-    server.stop(do_test_finished);
-    Svc.Prefs.resetBranch("");
-    Records.clearCache();
-  }
-}
+      // There are newly failed records and they are reported.
+      do_check_eq(called, 1);
+      do_check_eq(counts.failed, 3);
+      do_check_eq(counts.applied, 15);
+      do_check_eq(counts.newFailed, 3);
+
+      // Sync again, 1 of the failed items are the same, the rest didn't fail.
+      engine._processIncoming();
+
+      // Confirming removed failures.
+      do_check_eq([id for (id in engine._store.items)].length, 14);
+      do_check_eq(engine.previousFailed.length, 1);
+      do_check_eq(engine.previousFailed[0], "record-no-0");
+
+      // Failures weren't notified again because there were no newly failed items.
+      do_check_eq(called, 1);
+      do_check_eq(counts.failed, 3);
+      do_check_eq(counts.applied, 15);
+      do_check_eq(counts.newFailed, 3);
+    } finally {
+      server.stop(run_next_test);
+      Svc.Prefs.resetBranch("");
+      Records.clearCache();
+    }
+  });
+});
 
 
-function test_processIncoming_previousFailed() {
+add_test(function test_processIncoming_previousFailed() {
   _("Ensure that failed records are retried.");
   let syncTesting = new SyncTestingInfrastructure();
   Svc.Prefs.set("clusterURL", "http://localhost:8080/");
   Svc.Prefs.set("username", "foo");
   Svc.Prefs.set("client.type", "mobile");
-  
+
   const APPLY_BATCH_SIZE = 4;
   const NUMBER_OF_RECORDS = 14;
 
   // Engine that fails the first 2 records.
   let engine = makeSteamEngine();
-  engine.mobileGUIDFetchBatchSize = engine.applyIncomingBatchSize = APPLY_BATCH_SIZE;  
+  engine.mobileGUIDFetchBatchSize = engine.applyIncomingBatchSize = APPLY_BATCH_SIZE;
   engine._store._applyIncomingBatch = engine._store.applyIncomingBatch;
   engine._store.applyIncomingBatch = function (records) {
     engine._store._applyIncomingBatch(records.slice(2));
@@ -903,62 +865,64 @@ function test_processIncoming_previousFailed() {
   let server = sync_httpd_setup({
       "/1.1/foo/storage/steam": collection.handler()
   });
-  do_test_pending();
 
-  try {
-    // Confirm initial environment.
-    do_check_eq(engine.lastSync, 0);
-    do_check_eq(engine.toFetch.length, 0);
-    do_check_eq(engine.previousFailed.length, 0);
-    do_check_eq([id for (id in engine._store.items)].length, 0);
+  // Confirm initial environment.
+  do_check_eq(engine.lastSync, 0);
+  do_check_eq(engine.toFetch.length, 0);
+  do_check_eq(engine.previousFailed.length, 0);
+  do_check_eq([id for (id in engine._store.items)].length, 0);
 
-    // Initial failed items in previousFailed to be reset.
-    let previousFailed = [Utils.makeGUID(), Utils.makeGUID(), Utils.makeGUID()];
-    engine.previousFailed = previousFailed;
-    do_check_eq(engine.previousFailed, previousFailed);
+  // Initial failed items in previousFailed to be reset.
+  let previousFailed = [Utils.makeGUID(), Utils.makeGUID(), Utils.makeGUID()];
+  engine.previousFailed = previousFailed;
+  do_check_eq(engine.previousFailed, previousFailed);
 
-    // Do sync.
-    engine._syncStartup();
-    engine._processIncoming();
+  // Do sync.
+  engine._syncStartupCb(function (err) {
+    do_check_true(!err);
 
-    // Expected result: 4 sync batches with 2 failures each => 8 failures
-    do_check_eq([id for (id in engine._store.items)].length, 6);
-    do_check_eq(engine.previousFailed.length, 8);
-    do_check_eq(engine.previousFailed[0], "record-no-0");
-    do_check_eq(engine.previousFailed[1], "record-no-1");
-    do_check_eq(engine.previousFailed[2], "record-no-4");
-    do_check_eq(engine.previousFailed[3], "record-no-5");
-    do_check_eq(engine.previousFailed[4], "record-no-8");
-    do_check_eq(engine.previousFailed[5], "record-no-9");
-    do_check_eq(engine.previousFailed[6], "record-no-12");
-    do_check_eq(engine.previousFailed[7], "record-no-13");
+    try {
+      engine._processIncoming();
 
-    // Sync again with the same failed items (records 0, 1, 8, 9).
-    engine._processIncoming();
+      // Expected result: 4 sync batches with 2 failures each => 8 failures
+      do_check_eq([id for (id in engine._store.items)].length, 6);
+      do_check_eq(engine.previousFailed.length, 8);
+      do_check_eq(engine.previousFailed[0], "record-no-0");
+      do_check_eq(engine.previousFailed[1], "record-no-1");
+      do_check_eq(engine.previousFailed[2], "record-no-4");
+      do_check_eq(engine.previousFailed[3], "record-no-5");
+      do_check_eq(engine.previousFailed[4], "record-no-8");
+      do_check_eq(engine.previousFailed[5], "record-no-9");
+      do_check_eq(engine.previousFailed[6], "record-no-12");
+      do_check_eq(engine.previousFailed[7], "record-no-13");
 
-    // A second sync with the same failed items should not add the same items again.
-    // Items that did not fail a second time should no longer be in previousFailed.
-    do_check_eq([id for (id in engine._store.items)].length, 10);
-    do_check_eq(engine.previousFailed.length, 4);
-    do_check_eq(engine.previousFailed[0], "record-no-0");
-    do_check_eq(engine.previousFailed[1], "record-no-1");
-    do_check_eq(engine.previousFailed[2], "record-no-8");
-    do_check_eq(engine.previousFailed[3], "record-no-9");
+      // Sync again with the same failed items (records 0, 1, 8, 9).
+      engine._processIncoming();
 
-    // Refetched items that didn't fail the second time are in engine._store.items.
-    do_check_eq(engine._store.items['record-no-4'], "Record No. 4");
-    do_check_eq(engine._store.items['record-no-5'], "Record No. 5");
-    do_check_eq(engine._store.items['record-no-12'], "Record No. 12");
-    do_check_eq(engine._store.items['record-no-13'], "Record No. 13");
-  } finally {
-    server.stop(do_test_finished);
-    Svc.Prefs.resetBranch("");
-    Records.clearCache();
-  }
-}
+      // A second sync with the same failed items should not add the same items again.
+      // Items that did not fail a second time should no longer be in previousFailed.
+      do_check_eq([id for (id in engine._store.items)].length, 10);
+      do_check_eq(engine.previousFailed.length, 4);
+      do_check_eq(engine.previousFailed[0], "record-no-0");
+      do_check_eq(engine.previousFailed[1], "record-no-1");
+      do_check_eq(engine.previousFailed[2], "record-no-8");
+      do_check_eq(engine.previousFailed[3], "record-no-9");
+
+      // Refetched items that didn't fail the second time are in engine._store.items.
+      do_check_eq(engine._store.items['record-no-4'], "Record No. 4");
+      do_check_eq(engine._store.items['record-no-5'], "Record No. 5");
+      do_check_eq(engine._store.items['record-no-12'], "Record No. 12");
+      do_check_eq(engine._store.items['record-no-13'], "Record No. 13");
+    } finally {
+      server.stop(run_next_test);
+      Svc.Prefs.resetBranch("");
+      Records.clearCache();
+    }
+  });
+});
 
 
-function test_processIncoming_failed_records() {
+add_test(function test_processIncoming_failed_records() {
   _("Ensure that failed records from _reconcile and applyIncomingBatch are refetched.");
   let syncTesting = new SyncTestingInfrastructure();
   Svc.Prefs.set("clusterURL", "http://localhost:8080/");
@@ -1022,80 +986,77 @@ function test_processIncoming_failed_records() {
   let server = sync_httpd_setup({
       "/1.1/foo/storage/steam": recording_handler(collection)
   });
-  do_test_pending();
 
-  try {
+  // Confirm initial environment
+  do_check_eq(engine.lastSync, 0);
+  do_check_eq(engine.toFetch.length, 0);
+  do_check_eq(engine.previousFailed.length, 0);
+  do_check_eq([id for (id in engine._store.items)].length, 0);
 
-    // Confirm initial environment
-    do_check_eq(engine.lastSync, 0);
-    do_check_eq(engine.toFetch.length, 0);
-    do_check_eq(engine.previousFailed.length, 0);
-    do_check_eq([id for (id in engine._store.items)].length, 0);
+  let observerSubject;
+  let observerData;
+  Svc.Obs.add("weave:engine:sync:apply-failed",
+              function onApplyFailed(subject, data) {
+    Svc.Obs.remove("weave:engine:sync:apply-failed", onApplyFailed);
+    observerSubject = subject;
+    observerData = data;
+  });
 
-    let observerSubject;
-    let observerData;
-    Svc.Obs.add("weave:engine:sync:apply-failed",
-                function onApplyFailed(subject, data) {
-      Svc.Obs.remove("weave:engine:sync:apply-failed", onApplyFailed);
-      observerSubject = subject;
-      observerData = data;
-    });
-
-    engine._syncStartup();
-    engine._processIncoming();
-
-    // Ensure that all records but the bogus 4 have been applied.
-    do_check_eq([id for (id in engine._store.items)].length,
-                NUMBER_OF_RECORDS - BOGUS_RECORDS.length);
-
-    // Ensure that the bogus records will be fetched again on the next sync.
-    do_check_eq(engine.previousFailed.length, BOGUS_RECORDS.length);
-    engine.previousFailed.sort();
-    BOGUS_RECORDS.sort();
-    for (let i = 0; i < engine.previousFailed.length; i++) {
-      do_check_eq(engine.previousFailed[i], BOGUS_RECORDS[i]);
-    }
-
-    // Ensure the observer was notified
-    do_check_eq(observerData, engine.name);
-    do_check_eq(observerSubject.failed, BOGUS_RECORDS.length);
-
-    // Testing batching of failed item fetches.
-    // Try to sync again. Ensure that we split the request into chunks to avoid
-    // URI length limitations.
-    function batchDownload(batchSize) {
-      count = 0;
-      uris  = [];
-      engine.guidFetchBatchSize = batchSize;
+  engine._syncStartupCb(function (err) {
+    try {
       engine._processIncoming();
-      _("Tried again. Requests: " + count + "; URIs: " + JSON.stringify(uris));
-      return count;
+      _("_processIncoming done.");
+
+      // Ensure that all records but the bogus 4 have been applied.
+      do_check_eq([id for (id in engine._store.items)].length,
+                  NUMBER_OF_RECORDS - BOGUS_RECORDS.length);
+
+      // Ensure that the bogus records will be fetched again on the next sync.
+      do_check_eq(engine.previousFailed.length, BOGUS_RECORDS.length);
+      engine.previousFailed.sort();
+      BOGUS_RECORDS.sort();
+      for (let i = 0; i < engine.previousFailed.length; i++) {
+        do_check_eq(engine.previousFailed[i], BOGUS_RECORDS[i]);
+      }
+
+      // Ensure the observer was notified
+      do_check_eq(observerData, engine.name);
+      do_check_eq(observerSubject.failed, BOGUS_RECORDS.length);
+
+      // Testing batching of failed item fetches.
+      // Try to sync again. Ensure that we split the request into chunks to avoid
+      // URI length limitations.
+      function batchDownload(batchSize) {
+        count = 0;
+        uris  = [];
+        engine.guidFetchBatchSize = batchSize;
+        engine._processIncoming();
+        _("Tried again. Requests: " + count + "; URIs: " + JSON.stringify(uris));
+        return count;
+      }
+
+      // There are 8 bad records, so this needs 3 additional fetches.
+      // There's always one fetch for "records since".
+      _("Test batching with ID batch size 3, normal mobile batch size.");
+      do_check_eq(batchDownload(3), 4);
+
+      // Now see with a more realistic limit.
+      _("Test batching with sufficient ID batch size.");
+      do_check_eq(batchDownload(BOGUS_RECORDS.length), 2);
+
+      // If we're on mobile, that limit is used by default.
+      _("Test batching with tiny mobile batch size.");
+      Svc.Prefs.set("client.type", "mobile");
+      engine.mobileGUIDFetchBatchSize = 2;
+      do_check_eq(batchDownload(BOGUS_RECORDS.length), 5);
+
+    } finally {
+      cleanAndGo(server);
     }
-    
-    // There are 8 bad records, so this needs 3 fetches.
-    _("Test batching with ID batch size 3, normal mobile batch size.");
-    do_check_eq(batchDownload(3), 3);
+  });
+});
 
-    // Now see with a more realistic limit.
-    _("Test batching with sufficient ID batch size.");
-    do_check_eq(batchDownload(BOGUS_RECORDS.length), 1);
-
-    // If we're on mobile, that limit is used by default.
-    _("Test batching with tiny mobile batch size.");
-    Svc.Prefs.set("client.type", "mobile");
-    engine.mobileGUIDFetchBatchSize = 2;
-    do_check_eq(batchDownload(BOGUS_RECORDS.length), 4);
-
-  } finally {
-    server.stop(do_test_finished);
-    Svc.Prefs.resetBranch("");
-    Records.clearCache();
-    syncTesting = new SyncTestingInfrastructure(makeSteamEngine);
-  }
-}
-
-
-function test_processIncoming_decrypt_failed() {
+add_test(function test_processIncoming_decrypt_failed() {
   _("Ensure that records failing to decrypt are either replaced or refetched.");
   Svc.Prefs.set("clusterURL", "http://localhost:8080/");
   Svc.Prefs.set("username", "foo");
@@ -1135,7 +1096,6 @@ function test_processIncoming_decrypt_failed() {
   let server = sync_httpd_setup({
       "/1.1/foo/storage/steam": collection.handler()
   });
-  do_test_pending();
 
   try {
 
@@ -1167,14 +1127,12 @@ function test_processIncoming_decrypt_failed() {
     do_check_eq(observerSubject.failed, 4);
 
   } finally {
-    server.stop(do_test_finished);
-    Svc.Prefs.resetBranch("");
-    Records.clearCache();
+    cleanAndGo(server);
   }
-}
+});
 
 
-function test_uploadOutgoing_toEmptyServer() {
+add_test(function test_uploadOutgoing_toEmptyServer() {
   _("SyncEngine._uploadOutgoing uploads new records to server");
 
   let syncTesting = new SyncTestingInfrastructure();
@@ -1189,7 +1147,6 @@ function test_uploadOutgoing_toEmptyServer() {
       "/1.1/foo/storage/steam/flying": collection.wbos.flying.handler(),
       "/1.1/foo/storage/steam/scotsman": collection.wbos.scotsman.handler()
   });
-  do_test_pending();
   generateNewKeys();
 
   let engine = makeSteamEngine();
@@ -1203,39 +1160,37 @@ function test_uploadOutgoing_toEmptyServer() {
   meta_global.payload.engines = {steam: {version: engine.version,
                                          syncID: engine.syncID}};
 
-  try {
+  // Confirm initial environment
+  do_check_eq(engine.lastSyncLocal, 0);
+  do_check_eq(collection.wbos.flying.payload, undefined);
+  do_check_eq(collection.wbos.scotsman.payload, undefined);
 
-    // Confirm initial environment
-    do_check_eq(engine.lastSyncLocal, 0);
-    do_check_eq(collection.wbos.flying.payload, undefined);
-    do_check_eq(collection.wbos.scotsman.payload, undefined);
+  engine._syncStartupCb(function (err) {
+    try {
+      engine._uploadOutgoing();
 
-    engine._syncStartup();
-    engine._uploadOutgoing();
+      // Local timestamp has been set.
+      do_check_true(engine.lastSyncLocal > 0);
 
-    // Local timestamp has been set.
-    do_check_true(engine.lastSyncLocal > 0);
+      // Ensure the marked record ('scotsman') has been uploaded and is
+      // no longer marked.
+      do_check_eq(collection.wbos.flying.payload, undefined);
+      do_check_true(!!collection.wbos.scotsman.payload);
+      do_check_eq(JSON.parse(collection.wbos.scotsman.data.ciphertext).id,
+                  'scotsman');
+      do_check_eq(engine._tracker.changedIDs['scotsman'], undefined);
 
-    // Ensure the marked record ('scotsman') has been uploaded and is
-    // no longer marked.
-    do_check_eq(collection.wbos.flying.payload, undefined);
-    do_check_true(!!collection.wbos.scotsman.payload);
-    do_check_eq(JSON.parse(collection.wbos.scotsman.data.ciphertext).id,
-                'scotsman');
-    do_check_eq(engine._tracker.changedIDs['scotsman'], undefined);
+      // The 'flying' record wasn't marked so it wasn't uploaded
+      do_check_eq(collection.wbos.flying.payload, undefined);
 
-    // The 'flying' record wasn't marked so it wasn't uploaded
-    do_check_eq(collection.wbos.flying.payload, undefined);
-
-  } finally {
-    server.stop(do_test_finished);
-    Svc.Prefs.resetBranch("");
-    Records.clearCache();
-  }
-}
+    } finally {
+      cleanAndGo(server);
+    }
+  });
+});
 
 
-function test_uploadOutgoing_failed() {
+add_test(function test_uploadOutgoing_failed() {
   _("SyncEngine._uploadOutgoing doesn't clear the tracker of objects that failed to upload.");
 
   let syncTesting = new SyncTestingInfrastructure();
@@ -1249,7 +1204,6 @@ function test_uploadOutgoing_failed() {
   let server = sync_httpd_setup({
       "/1.1/foo/storage/steam": collection.handler()
   });
-  do_test_pending();
 
   let engine = makeSteamEngine();
   engine.lastSync = 123; // needs to be non-zero so that tracker is queried
@@ -1293,15 +1247,12 @@ function test_uploadOutgoing_failed() {
     do_check_eq(engine._tracker.changedIDs['peppercorn'], PEPPERCORN_CHANGED);
 
   } finally {
-    server.stop(do_test_finished);
-    Svc.Prefs.resetBranch("");
-    Records.clearCache();
-    syncTesting = new SyncTestingInfrastructure(makeSteamEngine);
+    cleanAndGo(server);
   }
-}
+});
 
 
-function test_uploadOutgoing_MAX_UPLOAD_RECORDS() {
+add_test(function test_uploadOutgoing_MAX_UPLOAD_RECORDS() {
   _("SyncEngine._uploadOutgoing uploads in batches of MAX_UPLOAD_RECORDS");
 
   let syncTesting = new SyncTestingInfrastructure();
@@ -1334,34 +1285,30 @@ function test_uploadOutgoing_MAX_UPLOAD_RECORDS() {
   let server = sync_httpd_setup({
       "/1.1/foo/storage/steam": collection.handler()
   });
-  do_test_pending();
 
-  try {
+  // Confirm initial environment
+  do_check_eq(noOfUploads, 0);
 
-    // Confirm initial environment
-    do_check_eq(noOfUploads, 0);
+  engine._syncStartupCb(function (err) {
+    try {
+      engine._uploadOutgoing();
 
-    engine._syncStartup();
-    engine._uploadOutgoing();
+      // Ensure all records have been uploaded
+      for (i = 0; i < 234; i++) {
+        do_check_true(!!collection.wbos['record-no-'+i].payload);
+      }
 
-    // Ensure all records have been uploaded
-    for (i = 0; i < 234; i++) {
-      do_check_true(!!collection.wbos['record-no-'+i].payload);
+      // Ensure that the uploads were performed in batches of MAX_UPLOAD_RECORDS
+      do_check_eq(noOfUploads, Math.ceil(234/MAX_UPLOAD_RECORDS));
+
+    } finally {
+      cleanAndGo(server);
     }
-
-    // Ensure that the uploads were performed in batches of MAX_UPLOAD_RECORDS
-    do_check_eq(noOfUploads, Math.ceil(234/MAX_UPLOAD_RECORDS));
-
-  } finally {
-    server.stop(do_test_finished);
-    Svc.Prefs.resetBranch("");
-    Records.clearCache();
-    syncTesting = new SyncTestingInfrastructure(makeSteamEngine);
-  }
-}
+  });
+});
 
 
-function test_syncFinish_noDelete() {
+add_test(function test_syncFinish_noDelete() {
   _("SyncEngine._syncFinish resets tracker's score");
   let engine = makeSteamEngine();
   engine._delete = {}; // Nothing to delete
@@ -1370,10 +1317,11 @@ function test_syncFinish_noDelete() {
   // _syncFinish() will reset the engine's score.
   engine._syncFinish();
   do_check_eq(engine.score, 0);
-}
+  run_next_test();
+});
 
 
-function test_syncFinish_deleteByIds() {
+add_test(function test_syncFinish_deleteByIds() {
   _("SyncEngine._syncFinish deletes server records slated for deletion (list of record IDs).");
 
   let syncTesting = new SyncTestingInfrastructure();
@@ -1393,7 +1341,6 @@ function test_syncFinish_deleteByIds() {
   let server = httpd_setup({
       "/1.1/foo/storage/steam": collection.handler()
   });
-  do_test_pending();
 
   let engine = makeSteamEngine();
   try {
@@ -1410,14 +1357,12 @@ function test_syncFinish_deleteByIds() {
     do_check_eq(engine._delete.ids, undefined);
 
   } finally {
-    server.stop(do_test_finished);
-    Svc.Prefs.resetBranch("");
-    Records.clearCache();
+    cleanAndGo(server);
   }
-}
+});
 
 
-function test_syncFinish_deleteLotsInBatches() {
+add_test(function test_syncFinish_deleteLotsInBatches() {
   _("SyncEngine._syncFinish deletes server records in batches of 100 (list of record IDs).");
 
   let syncTesting = new SyncTestingInfrastructure();
@@ -1447,7 +1392,6 @@ function test_syncFinish_deleteLotsInBatches() {
   let server = httpd_setup({
       "/1.1/foo/storage/steam": collection.handler()
   });
-  do_test_pending();
 
   let engine = makeSteamEngine();
   try {
@@ -1484,14 +1428,12 @@ function test_syncFinish_deleteLotsInBatches() {
     do_check_eq(engine._delete.ids, undefined);
 
   } finally {
-    server.stop(do_test_finished);
-    Svc.Prefs.resetBranch("");
-    Records.clearCache();
+    cleanAndGo(server);
   }
-}
+});
 
 
-function test_sync_partialUpload() {
+add_test(function test_sync_partialUpload() {
   _("SyncEngine.sync() keeps changedIDs that couldn't be uploaded.");
 
   let syncTesting = new SyncTestingInfrastructure();
@@ -1502,7 +1444,6 @@ function test_sync_partialUpload() {
   let server = sync_httpd_setup({
       "/1.1/foo/storage/steam": collection.handler()
   });
-  do_test_pending();
   generateNewKeys();
 
   let engine = makeSteamEngine();
@@ -1561,13 +1502,11 @@ function test_sync_partialUpload() {
     }
 
   } finally {
-    server.stop(do_test_finished);
-    Svc.Prefs.resetBranch("");
-    Records.clearCache();
+    cleanAndGo(server);
   }
-}
+});
 
-function test_canDecrypt_noCryptoKeys() {
+add_test(function test_canDecrypt_noCryptoKeys() {
   _("SyncEngine.canDecrypt returns false if the engine fails to decrypt items on the server, e.g. due to a missing crypto key collection.");
   let syncTesting = new SyncTestingInfrastructure();
   Svc.Prefs.set("clusterURL", "http://localhost:8080/");
@@ -1584,7 +1523,6 @@ function test_canDecrypt_noCryptoKeys() {
   let server = sync_httpd_setup({
       "/1.1/foo/storage/steam": collection.handler()
   });
-  do_test_pending();
 
   let engine = makeSteamEngine();
   try {
@@ -1592,13 +1530,11 @@ function test_canDecrypt_noCryptoKeys() {
     do_check_false(engine.canDecrypt());
 
   } finally {
-    server.stop(do_test_finished);
-    Svc.Prefs.resetBranch("");
-    Records.clearCache();
+    cleanAndGo(server);
   }
-}
+});
 
-function test_canDecrypt_true() {
+add_test(function test_canDecrypt_true() {
   _("SyncEngine.canDecrypt returns true if the engine can decrypt the items on the server.");
   let syncTesting = new SyncTestingInfrastructure();
   Svc.Prefs.set("clusterURL", "http://localhost:8080/");
@@ -1615,18 +1551,14 @@ function test_canDecrypt_true() {
   let server = sync_httpd_setup({
       "/1.1/foo/storage/steam": collection.handler()
   });
-  do_test_pending();
 
   let engine = makeSteamEngine();
   try {
     do_check_true(engine.canDecrypt());
   } finally {
-    server.stop(do_test_finished);
-    Svc.Prefs.resetBranch("");
-    Records.clearCache();
+    cleanAndGo(server);
   }
-}
-
+});
 
 function run_test() {
   if (DISABLE_TESTS_BUG_604565)
@@ -1634,28 +1566,5 @@ function run_test() {
 
   generateNewKeys();
 
-  test_syncStartup_emptyOrOutdatedGlobalsResetsSync();
-  test_syncStartup_serverHasNewerVersion();
-  test_syncStartup_syncIDMismatchResetsClient();
-  test_processIncoming_emptyServer();
-  test_processIncoming_createFromServer();
-  test_processIncoming_reconcile();
-  test_processIncoming_mobile_batchSize();
-  test_processIncoming_store_toFetch();
-  test_processIncoming_resume_toFetch();
-  test_processIncoming_applyIncomingBatchSize_smaller();
-  test_processIncoming_applyIncomingBatchSize_multiple();
-  test_processIncoming_failed_items_reported_once();
-  test_processIncoming_previousFailed();
-  test_processIncoming_failed_records();
-  test_processIncoming_decrypt_failed();
-  test_uploadOutgoing_toEmptyServer();
-  test_uploadOutgoing_failed();
-  test_uploadOutgoing_MAX_UPLOAD_RECORDS();
-  test_syncFinish_noDelete();
-  test_syncFinish_deleteByIds();
-  test_syncFinish_deleteLotsInBatches();
-  test_sync_partialUpload();
-  test_canDecrypt_noCryptoKeys();
-  test_canDecrypt_true();
+  run_next_test();
 }

--- a/services/sync/tests/unit/test_syncengine_sync.js
+++ b/services/sync/tests/unit/test_syncengine_sync.js
@@ -1619,9 +1619,7 @@ function test_canDecrypt_true() {
 
   let engine = makeSteamEngine();
   try {
-
     do_check_true(engine.canDecrypt());
-
   } finally {
     server.stop(do_test_finished);
     Svc.Prefs.resetBranch("");

--- a/services/sync/tests/unit/xpcshell.ini
+++ b/services/sync/tests/unit/xpcshell.ini
@@ -21,6 +21,7 @@ tail =
 [test_clients_escape.js]
 [test_collection_inc_get.js]
 [test_collections_recovery.js]
+[test_concurrent_requests.js]
 [test_corrupt_keys.js]
 [test_engine.js]
 [test_enginemanager.js]


### PR DESCRIPTION
Some of these commits are quite granular for conceptual clarity.

Part 5: Resource work:
    \* Introduce AsyncCollection and IncrementalResource on top of AsyncResource.

Part 6: minor asyncifying:
    \* Asynchronous versions of Sync methods.
      \* Introduce Engine.wipeServerCb and Engine._resetClientCb.
      \* Make removeClientData asynchronous. Add async Service.startOverCb.
      \* Implement WBORecord.fetchCb, WBORecord.uploadCb.
      \* Code changes for async.js move.

Part 7: some cleanup:
    \* Whitespace and comments.

Part 8: more asyncifying:
    \* Implement _syncStartupCb, amending tests accordingly. Eliminate _syncStartup.

Part 9: more Resource work:
    \* Add extendResponse hook to Resource classes.
    \* Add the Resource itself as the third argument to callbacks. This is useful for Collection.

Part 10: _processIncoming:
    \* Big rework: make _processIncoming use async HTTP.
    \* Manually integrate Bug 659107 - Only report failure for newly failed items.
    \* Always persist the entire set of remaining GUIDs before updating lastSync time.

Part 11: more cleanup:
    \* Minor rearrangements and comment additions.
