### PR TITLE
Notifications in services-central

### DIFF
--- a/services/Makefile.in
+++ b/services/Makefile.in
@@ -43,7 +43,7 @@ VPATH     = @srcdir@
 include $(DEPTH)/config/autoconf.mk
 
 ifdef MOZ_SERVICES_SYNC
-PARALLEL_DIRS += common crypto sync
+PARALLEL_DIRS += common crypto sync notifications
 endif
 
 include $(topsrcdir)/config/rules.mk

--- a/services/common/tests/unit/head_helpers.js
+++ b/services/common/tests/unit/head_helpers.js
@@ -127,6 +127,19 @@ function readBytesFromInputStream(inputStream, count) {
   return new BinaryInputStream(inputStream).readBytes(count);
 }
 
+/*
+ * Ensure exceptions from inside callbacks leads to test failures.
+ */
+function ensureThrows(func) {
+  return function() {
+    try {
+      func.apply(this, arguments);
+    } catch (ex) {
+      do_throw(ex);
+    }
+  };
+}
+
 /**
  * Proxy auth helpers.
  */

--- a/services/common/tests/unit/xpcshell.ini
+++ b/services/common/tests/unit/xpcshell.ini
@@ -7,6 +7,7 @@ tail =
 
 [test_utils_atob.js]
 [test_utils_encodeBase32.js]
+[test_utils_json.js]
 [test_utils_makeURI.js]
 [test_utils_namedTimer.js]
 [test_utils_stackTrace.js]

--- a/services/makefiles.sh
+++ b/services/makefiles.sh
@@ -40,6 +40,7 @@ add_makefiles "
   services/common/Makefile
   services/crypto/Makefile
   services/crypto/component/Makefile
+  services/notifications/Makefile
   services/sync/Makefile
   services/sync/locales/Makefile
 "
@@ -48,6 +49,7 @@ if [ "$ENABLE_TESTS" ]; then
   add_makefiles "
     services/common/tests/Makefile
     services/crypto/tests/Makefile
+    services/notifications/tests/Makefile
     services/sync/tests/Makefile
   "
 fi

--- a/services/notifications/Makefile.in
+++ b/services/notifications/Makefile.in
@@ -1,0 +1,27 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at http://mozilla.org/MPL/2.0/.
+
+DEPTH     = ../..
+topsrcdir = @top_srcdir@
+srcdir    = @srcdir@
+VPATH     = @srcdir@
+
+include $(DEPTH)/config/autoconf.mk
+
+PREF_JS_EXPORTS = $(srcdir)/services-notifications.js
+
+modules := \
+  service.js \
+  $(NULL)
+
+source_modules = $(foreach module,$(modules),$(srcdir)/$(module))
+module_dir = $(FINAL_TARGET)/modules/services-notifications
+
+libs::
+	$(NSINSTALL) -D $(module_dir)
+	$(NSINSTALL) $(source_modules) $(module_dir)
+
+TEST_DIRS += tests
+
+include $(topsrcdir)/config/rules.mk

--- a/services/notifications/README
+++ b/services/notifications/README
@@ -1,0 +1,11 @@
+Here lies most of the moving parts for push notifcations in the browser. DOM
+and UI bindings will live elsewhere; these files deal with talking to the API,
+storing messages, and creating persistent connections to the notification
+server.
+
+Structure:
+
+services.js::Service
+  This is a singleton that manages API calls and message storage. It's an
+  instance of the NotificationSvc class. Messages and state are persisted to a
+  JSON file on disk.

--- a/services/notifications/service.js
+++ b/services/notifications/service.js
@@ -1,0 +1,24 @@
+const EXPORTED_SYMBOLS = ["Service"];
+
+const {classes: Cc, interfaces: Ci, results: Cr, utils: Cu} = Components;
+
+Cu.import("resource://services-common/preferences.js");
+
+const PREFS_BRANCH = "services.notifications.";
+
+
+function NotificationSvc() {
+  this.ready = false;
+  this.prefs = new Preferences(PREFS_BRANCH);
+}
+NotificationSvc.prototype = {
+
+  get serverURL() this.prefs.get("serverURL"),
+
+  onStartup: function onStartup() {
+    this.ready = true;
+  }
+};
+
+let Service = new NotificationSvc();
+Service.onStartup();

--- a/services/notifications/service.js
+++ b/services/notifications/service.js
@@ -2,23 +2,91 @@ const EXPORTED_SYMBOLS = ["Service"];
 
 const {classes: Cc, interfaces: Ci, results: Cr, utils: Cu} = Components;
 
+Cu.import("resource://services-common/log4moz.js");
 Cu.import("resource://services-common/preferences.js");
+Cu.import("resource://services-common/rest.js");
+Cu.import("resource://services-common/utils.js");
 
 const PREFS_BRANCH = "services.notifications.";
 
-
 function NotificationSvc() {
-  this.ready = false;
   this.prefs = new Preferences(PREFS_BRANCH);
+  this.DB = {};
+
+  this._log = Log4Moz.repository.getLogger("Notifications.Service");
+  this._log.level = Log4Moz.Level[this.prefs.get("logger.level")];
 }
 NotificationSvc.prototype = {
 
-  get serverURL() this.prefs.get("serverURL"),
+  /**
+   * Path in the profile dir where we save our state.
+   */
+  filePath: "notifications/notifications",
 
-  onStartup: function onStartup() {
-    this.ready = true;
+  /**
+   * Get the serverURL pref without a trailing slash.
+   */
+  get serverURL() {
+    let url = this.prefs.get("serverURL");
+    let last = url.length - 1;
+    return url[last] == "/" ? url.substring(0, last) : url;
+  },
+
+  init: function init() {
+    this.loadState();
+  },
+
+  /**
+   * Load database state from a file.
+   */
+  loadState: function loadState(cb) {
+    CommonUtils.jsonLoad(this.filePath, this, function(json) {
+      if (json) {
+        this._log.info("Loading state from " + this.filePath);
+        this.DB = json;
+      }
+      if (cb) cb(null, json);
+    });
+  },
+
+  /**
+   * Save the current state to a file.
+   */
+  saveState: function saveState(cb) {
+    this._log.info("Saving state to " + this.filePath);
+    CommonUtils.jsonSave(this.filePath, this, this.DB, cb);
+  },
+
+  /**
+   * Get an authentication token from the local DB or the push server.
+   */
+  getToken: function getToken(cb) {
+    if (this.DB.token) {
+      this._log.debug("getToken from database");
+      return cb(null, this.DB.token);
+    }
+
+    let self = this;
+    let url = this.serverURL + "/token/";
+    new RESTRequest(url).get(function onResponse(error) {
+      if (error) {
+        return cb(error.message);
+      }
+      if (!this.response.success) {
+        return cb("Service error: " + this.response.status);
+      }
+      try {
+        self.DB.token = JSON.parse(this.response.body).token;
+        self.saveState();
+      } catch (e) {
+        return cb("bad json");
+      }
+
+      this._log.debug("getToken from server");
+      cb(null, self.DB.token);
+    });
   }
 };
 
 let Service = new NotificationSvc();
-Service.onStartup();
+Service.init();

--- a/services/notifications/services-notifications.js
+++ b/services/notifications/services-notifications.js
@@ -1,0 +1,1 @@
+pref("services.notifications.serverURL", "https://notifications.mozilla.org/");

--- a/services/notifications/services-notifications.js
+++ b/services/notifications/services-notifications.js
@@ -1,1 +1,2 @@
 pref("services.notifications.serverURL", "https://notifications.mozilla.org/");
+pref("services.notifications.logger.level", "Info");

--- a/services/notifications/tests/Makefile.in
+++ b/services/notifications/tests/Makefile.in
@@ -1,0 +1,16 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at http://mozilla.org/MPL/2.0/.
+
+DEPTH          = ../../..
+topsrcdir      = @top_srcdir@
+srcdir         = @srcdir@
+VPATH          = @srcdir@
+relativesrcdir = services/notifications/tests
+
+include $(DEPTH)/config/autoconf.mk
+
+MODULE = test_services_notifications
+XPCSHELL_TESTS = unit
+
+include $(topsrcdir)/config/rules.mk

--- a/services/notifications/tests/unit/head_helpers.js
+++ b/services/notifications/tests/unit/head_helpers.js
@@ -1,0 +1,3 @@
+const {classes: Cc, interfaces: Ci, results: Cr, utils: Cu} = Components;
+
+let _ = function() print(Array.slice(arguments).join(" "));

--- a/services/notifications/tests/unit/head_helpers.js
+++ b/services/notifications/tests/unit/head_helpers.js
@@ -1,3 +1,42 @@
-const {classes: Cc, interfaces: Ci, results: Cr, utils: Cu} = Components;
+// Loads everything from Components.
+do_load_httpd_js();
+
+const TEST_SERVER_URL = "http://localhost:8080/";
 
 let _ = function() print(Array.slice(arguments).join(" "));
+
+
+function httpd_setup (handlers, port) {
+  let port   = port || 8080;
+  let server = new nsHttpServer();
+  for (let path in handlers) {
+    server.registerPathHandler(path, handlers[path]);
+  }
+  try {
+    server.start(port);
+  } catch (ex) {
+    _("==========================================");
+    _("Got exception starting HTTP server on port " + port);
+    _("Error: " + Utils.exceptionStr(ex));
+    _("Is there a process already listening on port " + port + "?");
+    _("==========================================");
+    do_throw(ex);
+  }
+  return server;
+}
+
+function httpd_handler(statusCode, status, body) {
+  return function handler(request, response) {
+    _("Processing request");
+    // Allow test functions to inspect the request.
+    request.body = readBytesFromInputStream(request.bodyInputStream);
+    handler.request = request;
+
+    response.setStatusLine(request.httpVersion, statusCode, status);
+    if (body) {
+      response.bodyOutputStream.write(body, body.length);
+    }
+  };
+}
+
+let PROFILE_DIR = do_get_profile();

--- a/services/notifications/tests/unit/test_get_token.js
+++ b/services/notifications/tests/unit/test_get_token.js
@@ -1,0 +1,109 @@
+function run_test() {
+  run_next_test();
+}
+
+Cu.import("resource://services-common/async.js");
+Cu.import("resource://services-notifications/service.js");
+
+const TOKEN = "TEST";
+
+
+add_test(function test_get_token_from_server() {
+  _("Test getting the token from the server.");
+
+  let server = httpd_setup({
+    "/token/": function(request, response) {
+      response.setStatusLine(request.httpVersion, 200, "OK");
+      response.setHeader("Content-Type", "application/json");
+
+      let body = JSON.stringify({token: TOKEN});
+      response.bodyOutputStream.write(body, body.length);
+    }
+  });
+
+  Service.prefs.set("serverURL", TEST_SERVER_URL);
+
+  Service.getToken(function(error, token) {
+    do_check_eq(error, null);
+    do_check_eq(token, TOKEN);
+    server.stop(run_next_test);
+  });
+});
+
+
+add_test(function test_get_token_from_memory() {
+  _("The token should be in Service.DB after the previous test.");
+  do_check_true(Service.DB.token == TOKEN);
+
+  Service.getToken(function(error, token) {
+    do_check_eq(error, null);
+    do_check_eq(token, TOKEN);
+    run_next_test();
+  });
+});
+
+
+add_test(function test_get_token_from_disk() {
+  _("The token should have been saved to disk by the previous test.");
+
+  /* Clear out local state, then load again from disk. */
+  Service.DB = {};
+  let spinner = Async.makeSpinningCallback();
+  Service.loadState(spinner);
+  let r = spinner.wait();
+
+  do_check_eq(Service.DB.token, TOKEN);
+
+  Service.getToken(function(error, token) {
+    do_check_eq(error, null);
+    do_check_eq(token, TOKEN);
+    run_next_test();
+  });
+});
+
+
+add_test(function test_get_token_network_error() {
+  _("No token for a network error.");
+  Service.DB = {};
+  Service.getToken(function(error, token) {
+    do_check_eq(error, "NS_ERROR_CONNECTION_REFUSED");
+    do_check_eq(token, undefined);
+    run_next_test();
+  });
+});
+
+
+add_test(function test_get_token_server_error() {
+  _("No token for a service error.");
+  let server = httpd_setup();
+
+  Service.prefs.set("serverURL", TEST_SERVER_URL);
+  Service.getToken(function(error, token) {
+    do_check_eq(error, "Service error: 404");
+    do_check_eq(token, undefined);
+    server.stop(run_next_test);
+  });
+});
+
+
+add_test(function test_get_token_from_server() {
+  _("Test getting the token from the server.");
+
+  let server = httpd_setup({
+    "/token/": function(request, response) {
+      response.setStatusLine(request.httpVersion, 200, "OK");
+      response.setHeader("Content-Type", "application/json");
+
+      let body = "oops";
+      response.bodyOutputStream.write(body, body.length);
+    }
+  });
+
+  Service.prefs.set("serverURL", TEST_SERVER_URL);
+
+  Service.getToken(function(error, token) {
+    do_check_eq(error, "bad json");
+    do_check_eq(token, undefined);
+    server.stop(run_next_test);
+  });
+});

--- a/services/notifications/tests/unit/test_service_start.js
+++ b/services/notifications/tests/unit/test_service_start.js
@@ -1,8 +1,7 @@
-// Check that everything is getting hooked together properly.
 function run_test() {
-  _("When imported, Service.onStartup is called.");
+  _("Check that a Notification Service is created during import.");
   Cu.import("resource://services-notifications/service.js");
 
-  do_check_eq(Service.serverURL, "http://push.jbalogh.me/");
-  do_check_eq(Service.ready, true);
+  Service.prefs.set("serverURL", "http://foo.bar.com/");
+  do_check_eq(Service.serverURL, "http://foo.bar.com");
 }

--- a/services/notifications/tests/unit/test_service_start.js
+++ b/services/notifications/tests/unit/test_service_start.js
@@ -1,0 +1,8 @@
+// Check that everything is getting hooked together properly.
+function run_test() {
+  _("When imported, Service.onStartup is called.");
+  Cu.import("resource://services-notifications/service.js");
+
+  do_check_eq(Service.serverURL, "http://push.jbalogh.me/");
+  do_check_eq(Service.ready, true);
+}

--- a/services/notifications/tests/unit/xpcshell.ini
+++ b/services/notifications/tests/unit/xpcshell.ini
@@ -1,0 +1,5 @@
+[DEFAULT]
+head = head_helpers.js
+tail =
+
+[test_service_start.js]

--- a/services/notifications/tests/unit/xpcshell.ini
+++ b/services/notifications/tests/unit/xpcshell.ini
@@ -3,3 +3,4 @@ head = head_helpers.js
 tail =
 
 [test_service_start.js]
+[test_get_token.js]

--- a/services/sync/SyncComponents.manifest
+++ b/services/sync/SyncComponents.manifest
@@ -21,3 +21,4 @@ contract @mozilla.org/network/protocol/about;1?what=sync-log {d28f8a0b-95da-48f4
 resource services-sync resource:///modules/services-sync/
 resource services-common resource:///modules/services-common/
 resource services-crypto resource:///modules/services-crypto/
+resource services-notifications resource:///modules/services-notifications/

--- a/services/sync/modules/util.js
+++ b/services/sync/modules/util.js
@@ -357,77 +357,12 @@ let Utils = {
     return Utils.encodeKeyBase32(atob(encodedKey));
   },
 
-  /**
-   * Load a json object from disk
-   *
-   * @param filePath
-   *        Json file path load from weave/[filePath].json
-   * @param that
-   *        Object to use for logging and "this" for callback
-   * @param callback
-   *        Function to process json object as its first parameter
-   */
-  jsonLoad: function Utils_jsonLoad(filePath, that, callback) {
-    filePath = "weave/" + filePath + ".json";
-    if (that._log)
-      that._log.trace("Loading json from disk: " + filePath);
-
-    let file = FileUtils.getFile("ProfD", filePath.split("/"), true);
-    if (!file.exists()) {
-      callback.call(that);
-      return;
-    }
-
-    let channel = NetUtil.newChannel(file);
-    channel.contentType = "application/json";
-
-    NetUtil.asyncFetch(channel, function (is, result) {
-      if (!Components.isSuccessCode(result)) {
-        callback.call(that);
-        return;
-      }
-      let string = NetUtil.readInputStreamToString(is, is.available());
-      is.close();
-      let json;
-      try {
-        json = JSON.parse(string);
-      } catch (ex) {
-        if (that._log)
-          that._log.debug("Failed to load json: " + Utils.exceptionStr(ex));
-      }
-      callback.call(that, json);
-    });
+  jsonLoad: function jsonLoad(path, that, callback) {
+    CommonUtils.jsonLoad("weave/" + path, that, callback);
   },
 
-  /**
-   * Save a json-able object to disk
-   *
-   * @param filePath
-   *        Json file path save to weave/[filePath].json
-   * @param that
-   *        Object to use for logging and "this" for callback
-   * @param obj
-   *        Function to provide json-able object to save. If this isn't a
-   *        function, it'll be used as the object to make a json string.
-   * @param callback
-   *        Function called when the write has been performed. Optional.
-   */
-  jsonSave: function Utils_jsonSave(filePath, that, obj, callback) {
-    filePath = "weave/" + filePath + ".json";
-    if (that._log)
-      that._log.trace("Saving json to disk: " + filePath);
-
-    let file = FileUtils.getFile("ProfD", filePath.split("/"), true);
-    let json = typeof obj == "function" ? obj.call(that) : obj;
-    let out = JSON.stringify(json);
-
-    let fos = FileUtils.openSafeFileOutputStream(file);
-    let is = this._utf8Converter.convertToInputStream(out);
-    NetUtil.asyncCopy(is, fos, function (result) {
-      if (typeof callback == "function") {
-        callback.call(that);        
-      }
-    });
+  jsonSave: function jsonSave(path, that, obj, callback) {
+    CommonUtils.jsonSave("weave/" + path, that, obj, callback);
   },
 
   getIcon: function(iconUri, defaultIcon) {

--- a/services/sync/tests/unit/head_helpers.js
+++ b/services/sync/tests/unit/head_helpers.js
@@ -251,20 +251,6 @@ function SyncTestingInfrastructure(username, password, syncKey) {
   this.fakeCryptoService = new FakeCryptoService();
 }
 
-/*
- * Ensure exceptions from inside callbacks leads to test failures.
- */
-function ensureThrows(func) {
-  return function() {
-    try {
-      func.apply(this, arguments);
-    } catch (ex) {
-      do_throw(ex);
-    }
-  };
-}
-
-
 _("Setting the identity for passphrase");
 Cu.import("resource://services-sync/identity.js");
 

--- a/services/sync/tests/unit/xpcshell.ini
+++ b/services/sync/tests/unit/xpcshell.ini
@@ -18,7 +18,6 @@ tail =
 [test_utils_keyEncoding.js]
 [test_utils_getErrorString.js]
 [test_utils_getIcon.js]
-[test_utils_json.js]
 [test_utils_lazyStrings.js]
 [test_utils_lock.js]
 [test_utils_makeGUID.js]

--- a/testing/xpcshell/xpcshell.ini
+++ b/testing/xpcshell/xpcshell.ini
@@ -71,6 +71,7 @@ skip-if = os == "android"
 [include:services/common/tests/unit/xpcshell.ini]
 [include:services/crypto/tests/unit/xpcshell.ini]
 [include:services/crypto/components/tests/unit/xpcshell.ini]
+[include:services/notifications/tests/unit/xpcshell.ini]
 [include:services/sync/tests/unit/xpcshell.ini]
 # Bug 676978: tests hang on Android 
 skip-if = os == "android"


### PR DESCRIPTION
Hey guys I wrote some code I hope you like it! (cc @mconnormoz @indygreg @rnewman)

Are pull requests ok? Would you rather have this in Bugzilla?

This is a couple patches that start up services/notifications. I don't know what I'm doing inside Firefox, so the structure and style are probably not great. Some parts I copy/pasted. Please be harsh.

I think the `NotificationSvc` singleton should eventually become something like the app-startup WeaveService.

Here's the server API: http://push.rtfd.org#client-http-api

From the README:

Here lies most of the moving parts for push notifcations in the browser. DOM
and UI bindings will live elsewhere; these files deal with talking to the API,
storing messages, and creating persistent connections to the notification
server.

Structure:

services.js::Service
  This is a singleton that manages API calls and message storage. It's an
  instance of the NotificationSvc class. Messages and state are persisted to a
  JSON file on disk.
